### PR TITLE
perf: add lazy loading for Mermaid charts with Intersection Observer

### DIFF
--- a/src/pages/ChatPage/components/MessageCard/index.tsx
+++ b/src/pages/ChatPage/components/MessageCard/index.tsx
@@ -11,7 +11,7 @@ import {
   createFavoriteButton,
   createReferenceButton,
 } from "../ActionButtonGroup";
-import { selectCurrentChat, useAppStore } from "../../store";
+import { useAppStore } from "../../store";
 import {
   isTodoListMessage,
   isUserFileReferenceMessage,

--- a/src/shared/components/Markdown/MarkdownCodeBlock.tsx
+++ b/src/shared/components/Markdown/MarkdownCodeBlock.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button, Card, message } from "antd";
 import { CopyOutlined } from "@ant-design/icons";
-import { MermaidChart } from "../MermaidChart";
+import LazyMermaidChart from "../MermaidChart/LazyMermaidChart";
 import {
   getSyntaxTheme,
   registeredLanguages,
@@ -119,7 +119,7 @@ export const renderCodeBlock = (
         console.warn("Empty Mermaid chart content");
         return null;
       }
-      return <MermaidChart chart={trimmedChart} onFix={onFixMermaid} />;
+      return <LazyMermaidChart chart={trimmedChart} onFix={onFixMermaid} />;
     }
 
     return (

--- a/src/shared/components/MermaidChart/LazyMermaidChart.tsx
+++ b/src/shared/components/MermaidChart/LazyMermaidChart.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Spin } from "antd";
+import type { MermaidChartProps } from "./index";
+import { MermaidChart } from "./index";
+
+const LazyMermaidChart: React.FC<MermaidChartProps> = (props) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            // Once visible, start rendering after a small delay to avoid layout thrashing
+            requestAnimationFrame(() => {
+              setShouldRender(true);
+            });
+            // Stop observing once visible
+            observer.disconnect();
+          }
+        });
+      },
+      {
+        rootMargin: "100px", // Start loading 100px before entering viewport
+        threshold: 0.01, // Trigger when even 1% is visible
+      },
+    );
+
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} style={{ minHeight: isVisible ? "auto" : "200px" }}>
+      {shouldRender ? (
+        <MermaidChart {...props} />
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "200px",
+            background: "transparent",
+          }}
+        >
+          {isVisible && <Spin size="small" tip="Loading diagram..." />}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(LazyMermaidChart);


### PR DESCRIPTION
## Summary

Implement lazy loading for Mermaid diagrams to improve performance when opening long sessions with many charts.

### Problem
Opening a long session with multiple Mermaid diagrams took 477ms+ for rendering, even with virtual scrolling. All visible charts were rendered immediately, causing significant performance impact.

### Solution
- Created `LazyMermaidChart` component using Intersection Observer API
- Charts only render when they enter the viewport (with 100px rootMargin for smooth UX)
- Show loading spinner while chart is being rendered
- Updated `MarkdownCodeBlock` to use lazy loading instead of eager rendering

### Performance Impact
- **Before**: All visible Mermaid charts render immediately (477ms+ for long sessions)
- **After**: Only charts in/near viewport are rendered, reducing initial load time significantly

### Additional Fixes
- Fixed tool name tracking in `useAgentEventSubscription` (track in `onToolStart`, retrieve in `onToolComplete`)
- Removed unused `selectCurrentChat` import from `MessageCard`

## Test Plan

- [x] Build succeeds without errors
- [ ] Manual testing: Open long session with multiple Mermaid charts
- [ ] Verify: Charts load lazily as user scrolls
- [ ] Verify: Loading spinner shows while rendering
- [ ] Verify: No performance regression for sessions without charts
- [ ] Verify: Tool name is correctly tracked across start/complete events

🤖 Generated with [Claude Code](https://claude.com/claude-code)