### PR TITLE
fix: upgrade bamboo-agent to 0.2.3 to fix route shadowing bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,13 @@ Bamboo uses an **embedded architecture** where the bamboo-agent HTTP server runs
 │  │   └── HTTP API → localhost:8080      │
 │  ├── Embedded Web Service Manager       │
 │  │   └── tokio::spawn(HTTP server)      │
-│  └── bamboo-agent (v0.1.0)              │
+│  └── bamboo-agent (v0.2.2)              │
 │      └── HTTP Server (port 8080)        │
 └─────────────────────────────────────────┘
 ```
 
 **Key Components**:
-- **bamboo-agent crate** (v0.1.0 from crates.io) - Provides all agent functionality
+- **bamboo-agent crate** (v0.2.2 from crates.io) - Provides all agent functionality
 - **EmbeddedWebService** - Manages HTTP server lifecycle within the app process
 - **Health check monitoring** - Ensures server is ready before accepting requests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bamboo-agent"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003960dd83f8a6d91a04a2b3fa3dc5ef009e7bf01b7a119db6cfb3d9fb815a87"
+checksum = "b198d9c0d07a61345d396a42fc9b5f6a2e16e2a429257c656d45224918d5b0f7"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "copilot_chat"
-version = "0.1.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "bamboo-agent",
  "clap",
  "env_logger",
+ "log",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bamboo-agent"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b198d9c0d07a61345d396a42fc9b5f6a2e16e2a429257c656d45224918d5b0f7"
+checksum = "08f0bee256822ad16aa8293c0c3a69fc3613cdf62d90bc5eaceebdf8b92a2a87"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/e2e-backend/Cargo.toml
+++ b/e2e-backend/Cargo.toml
@@ -8,7 +8,7 @@ name = "web_service_standalone"
 path = "src/main.rs"
 
 [dependencies]
-bamboo-agent = { version = "^0.1.1", default-features = false }
+bamboo-agent = { version = "0.2.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"

--- a/e2e-backend/Cargo.toml
+++ b/e2e-backend/Cargo.toml
@@ -12,3 +12,4 @@ bamboo-agent = { version = "0.2.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
+log = "0.4"

--- a/e2e-backend/Cargo.toml
+++ b/e2e-backend/Cargo.toml
@@ -8,7 +8,7 @@ name = "web_service_standalone"
 path = "src/main.rs"
 
 [dependencies]
-bamboo-agent = { version = "0.2.2", default-features = false }
+bamboo-agent = { version = "0.2.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot_chat",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true }
 
 [dependencies]
-bamboo-agent = "0.2.2"
+bamboo-agent = "0.2.3"
 
 # Tauri core and plugins
 tauri = { workspace = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copilot_chat"
-version = "0.1.1"
+version = "0.2.2"
 description = "A Tauri App"
 authors = ["bigduu"]
 edition = "2021"
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true }
 
 [dependencies]
-bamboo-agent = "~0.1.1"
+bamboo-agent = "0.2.2"
 
 # Tauri core and plugins
 tauri = { workspace = true }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentChat",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "identifier": "com.agent.chat",
   "build": {
     "beforeDevCommand": "yarn dev",


### PR DESCRIPTION
## Summary
- Fix /v1/bamboo/setup/complete endpoint returning 404
- Upgrade bamboo-agent from 0.2.2 to 0.2.3
- Fix route registration order issue

## Problem
- All `/v1/bamboo/*` endpoints were inaccessible and returned 404
- Other `/v1/*` endpoints (like `/v1/models`) worked fine
- E2E tests were failing because setup endpoints could not be called

## Root Cause
- bamboo-agent 0.2.2 registered `openai_routes` (with empty scope) before bamboo routes
- In Actix-web, empty scope `web::scope("")` matches all paths under `/v1`
- Routes are matched with "first match wins" strategy
- This caused all `/v1/bamboo/*` requests to be intercepted by the empty scope

## Solution
- Upgrade to bamboo-agent 0.2.3 which fixes the route ordering
- Version 0.2.3 moves `openai_routes` registration to the end
- This prevents the empty scope from shadowing bamboo routes

## Testing
- ✅ Tested locally: `/v1/bamboo/setup/status` now returns 200
- ✅ Tested locally: `/v1/bamboo/setup/complete` now returns 200
- ✅ E2E tests can now access setup endpoints
- ✅ Added route ordering test in bamboo-agent repository

## Related
- bamboo-agent PR: https://github.com/bigduu/Bamboo-agent/pull/1
- bamboo-agent release: v0.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)