### PR TITLE
fix(release): build the real bamboo sidecar in CI (was shipping exit-1 placeholder)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         description: "bamboo-agent crate version to embed (default: latest)"
         required: false
         default: "latest"
+      bamboo_ref:
+        description: "Git ref of bigduu/Bamboo-agent to build the sidecar from (default: main)"
+        required: false
+        default: "main"
       lotus_version:
         description: "Lotus npm version to bundle (default: latest)"
         required: false
@@ -62,6 +66,19 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
+
+      # The bamboo sidecar is built from source (not the crates.io crate): the
+      # published bamboo-agent crate does NOT ship frontend_package/, so a
+      # `cargo install` would yield a backend with no embedded lotus UI. Building
+      # the source tree lets scripts/build-sidecar.cjs embed lotus and produce a
+      # self-contained `bamboo serve` binary. Without this the bundle ships the
+      # build.rs placeholder (`exit 1`) and the app hangs on "Starting Bodhi…".
+      - name: Checkout Bamboo source (sidecar backend)
+        uses: actions/checkout@v6
+        with:
+          repository: bigduu/Bamboo-agent
+          ref: ${{ github.event.inputs.bamboo_ref || 'main' }}
+          path: bamboo-src
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'
@@ -145,7 +162,9 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: "./src-tauri -> target"
+          workspaces: |
+            ./src-tauri -> target
+            ./bamboo-src -> target
           shared-key: "bodhi-release-${{ matrix.target }}"
           cache-on-failure: true
 
@@ -191,6 +210,20 @@ jobs:
           echo "Using @bigduu/lotus@${LOTUS_VERSION}"
           npm install --no-save "@bigduu/lotus@${LOTUS_VERSION}"
 
+      - name: Install Lotus into Bamboo source (sidecar frontend embed)
+        # build-sidecar.cjs runs bamboo's frontend-package.cjs in LOTUS_SOURCE=package
+        # mode, which resolves @bigduu/lotus from the bamboo checkout's node_modules
+        # and embeds its prebuilt dist into the `bamboo` binary.
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.lotus_version }}" ]; then
+            LOTUS_VERSION="${{ github.event.inputs.lotus_version }}"
+          else
+            LOTUS_VERSION="latest"
+          fi
+          echo "Installing @bigduu/lotus@${LOTUS_VERSION} into bamboo-src"
+          npm install --no-save --prefix bamboo-src "@bigduu/lotus@${LOTUS_VERSION}"
+
       - name: Stage Lotus dist for bundling
         shell: bash
         run: |
@@ -204,6 +237,14 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Build the bamboo sidecar from the checked-out source for THIS matrix
+          # target. build-sidecar.cjs (the configured beforeBuildCommand) reads
+          # these: it embeds lotus (LOTUS_SOURCE=package, job env) and cross-builds
+          # the binary to the app's triple so externalBin resolves to a real
+          # backend instead of the build.rs `exit 1` placeholder.
+          BAMBOO_SIDECAR_SOURCE: local
+          BAMBOO_LOCAL_PATH: ${{ github.workspace }}/bamboo-src
+          BAMBOO_SIDECAR_TARGET: ${{ matrix.target }}
           # Ad-hoc macOS signing: the runner keychain has no "Zenith Nova Code
           # Signing" cert (no Apple secrets configured), so the real identity in
           # tauri.conf can't be used and the build fails at codesign. "-" signs

--- a/scripts/build-sidecar.cjs
+++ b/scripts/build-sidecar.cjs
@@ -43,7 +43,14 @@ const bambooExists = () => {
 const SOURCE = (
   process.env.BAMBOO_SIDECAR_SOURCE || (bambooExists() ? "local" : "none")
 ).toLowerCase();
-const triple = hostTriple();
+// Target triple for the sidecar. Defaults to the build host, but CI cross-builds
+// (e.g. an x86_64 app on an arm64 macOS runner) set BAMBOO_SIDECAR_TARGET to the
+// matrix target so the sidecar's architecture matches the app and Tauri's
+// `externalBin` lookup (`bamboo-<target-triple>`) resolves to a real binary
+// instead of falling back to the build.rs placeholder.
+const host = hostTriple();
+const triple = (process.env.BAMBOO_SIDECAR_TARGET || "").trim() || host;
+const isCross = triple !== host;
 const isWin = triple.includes("windows");
 const ext = isWin ? ".exe" : "";
 const binDir = path.join(BODHI, "src-tauri", "binaries");
@@ -67,10 +74,16 @@ if (!isDebug) {
   sh("node scripts/frontend-package.cjs", BAMBOO);
 }
 
-console.log(`🔧 Building bamboo sidecar (${profile}) from ${BAMBOO} …`);
-sh(`cargo build --bin bamboo${isDebug ? "" : " --release"}`, BAMBOO);
+const targetFlag = isCross ? ` --target ${triple}` : "";
+console.log(
+  `🔧 Building bamboo sidecar (${profile}${isCross ? `, cross → ${triple}` : ""}) from ${BAMBOO} …`,
+);
+sh(`cargo build --bin bamboo${isDebug ? "" : " --release"}${targetFlag}`, BAMBOO);
 
-const built = path.join(BAMBOO, "target", profile, `bamboo${ext}`);
+// Cross builds land under target/<triple>/<profile>; host builds under target/<profile>.
+const built = isCross
+  ? path.join(BAMBOO, "target", triple, profile, `bamboo${ext}`)
+  : path.join(BAMBOO, "target", profile, `bamboo${ext}`);
 fs.copyFileSync(built, dest);
 if (!isWin) fs.chmodSync(dest, 0o755);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -227,6 +227,28 @@ fn setup<R: Runtime>(app: &mut App<R>) -> std::result::Result<(), Box<dyn std::e
             }
         } else {
             log::error!("bamboo backend never became healthy on port {port}");
+            // The webview is still on the boot splash (bodhi-splash/index.html).
+            // Replace its "Starting Bodhi…" spinner with an error so the user sees
+            // a failure instead of an indefinite spinner. Logs live under the
+            // bamboo sidecar data dir.
+            if let Some(win) = sidecar_app.get_webview_window("main") {
+                let js = format!(
+                    r#"
+                    (function () {{
+                      var wrap = document.querySelector('.wrap');
+                      if (!wrap) {{ wrap = document.body; }}
+                      wrap.innerHTML =
+                        "<div style='max-width:420px;text-align:center;font:13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#e0918a;'>" +
+                        "<div style='font-size:15px;margin-bottom:10px;'>Bodhi failed to start</div>" +
+                        "<div style='color:#9aa0a6;line-height:1.5;'>The local engine did not become ready on port {port} within 60s.<br/>Try restarting the app; if it persists, check the engine logs and report this.</div>" +
+                        "</div>";
+                    }})();
+                    "#
+                );
+                if let Err(e) = win.eval(&js) {
+                    log::warn!("failed to render startup-failure splash: {e}");
+                }
+            }
         }
     });
 


### PR DESCRIPTION
## Problem

GitHub release bundles hang forever on the **"Starting Bodhi…"** splash.

`release.yml` never built the bamboo sidecar. With no `../bamboo` checkout, `build-sidecar.cjs` falls back to keeping the `build.rs` placeholder — a `#!/bin/sh … exit 1` script. The shipped `.app` therefore spawned a "backend" that exits immediately, `wait_for_health` polled for 60s and failed, and the webview never navigated off the splash → permanent spinner.

## Fix

Build the sidecar **from source** in the release workflow (the published `bamboo-agent` crate omits `frontend_package/`, so `cargo install` would yield a UI-less backend):

- Checkout `bigduu/Bamboo-agent` (public) to `bamboo-src`; new `bamboo_ref` input (default `main`, matching the release-train refs).
- Install `@bigduu/lotus` into `bamboo-src` so `frontend-package.cjs` (package mode) embeds the UI.
- Pass `BAMBOO_SIDECAR_SOURCE` / `BAMBOO_LOCAL_PATH` / `BAMBOO_SIDECAR_TARGET` to `tauri-action` so the `beforeBuildCommand` produces a real binary at `binaries/bamboo-<target>`; `build.rs` then skips the placeholder.
- Cache `bamboo-src/target`.

**`build-sidecar.cjs`**: honor `BAMBOO_SIDECAR_TARGET` to cross-build the sidecar to the app's triple (e.g. x86_64 app on an arm64 macOS runner). Unset = host build, identical to before.

**`lib.rs`**: when the backend never becomes healthy (60s), replace the splash spinner with a visible "Bodhi failed to start" message instead of an indefinite spinner.

## Verification

- ✅ `build-sidecar.cjs` JS syntax, `release.yml` YAML parse, `src-tauri` `cargo check` all pass locally.
- ⚠️ Not yet run through CI — the cross-compile (macOS x64 on an arm64 runner) and lotus embedding need a real `release.yml` run to fully confirm. **Watch the macOS x64 job** on the first dispatch.

## Follow-up

- The **already-published broken release must be re-cut** after this lands.