### PR TITLE
fix(sidecar): embed lotus frontend into the bamboo sidecar (was API-only → app hung on splash)

### DIFF
--- a/scripts/build-sidecar.cjs
+++ b/scripts/build-sidecar.cjs
@@ -72,6 +72,26 @@ if (!bambooExists()) {
 if (!isDebug) {
   console.log("🔧 Building the embedded lotus frontend for the sidecar (production)…");
   sh("node scripts/frontend-package.cjs", BAMBOO);
+
+  // frontend-package.cjs stages the package at the bamboo workspace ROOT
+  // (frontend_package/), but bamboo-server's build.rs embeds it from ITS OWN
+  // crate dir (CARGO_MANIFEST_DIR/frontend_package) via include_bytes!. Since the
+  // crates were reorganized under crates/app/, those paths no longer line up, so
+  // the embed silently resolves to None and the sidecar compiles as an API-only
+  // server with no UI — the webview then navigates to a 404 and the app hangs on
+  // the "Starting Bodhi…" splash. Mirror the staged package into the crate dir so
+  // the compile-time embed actually picks it up.
+  const stagedPkg = path.join(BAMBOO, "frontend_package");
+  const serverPkg = path.join(BAMBOO, "crates", "app", "bamboo-server", "frontend_package");
+  if (fs.existsSync(path.join(stagedPkg, "lotus-frontend.zip"))) {
+    fs.rmSync(serverPkg, { recursive: true, force: true });
+    fs.cpSync(stagedPkg, serverPkg, { recursive: true });
+    console.log(`✅ mirrored frontend package → ${path.relative(BAMBOO, serverPkg)}`);
+  } else {
+    console.warn(
+      `⚠️  no staged frontend package at ${stagedPkg}; sidecar will be API-only (no UI)`,
+    );
+  }
 }
 
 const targetFlag = isCross ? ` --target ${triple}` : "";


### PR DESCRIPTION
## Problem

Follow-up to #54. Even after the sidecar was built from real source, the app still hangs on **"Starting Bodhi…"**. The bundled `bamboo serve` starts **API-only with no UI**, so the shell navigates the webview to the backend and `GET /` returns **404** — the splash never gets replaced.

## Root cause

`bamboo-server`'s `build.rs` embeds the frontend with:
```
include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend_package/lotus-frontend.zip"))
```
i.e. from `crates/app/bamboo-server/frontend_package/`.

But `frontend-package.cjs` stages the package at the **bamboo workspace ROOT** (`frontend_package/`). After bamboo reorganized its crates under `crates/app/` (`refactor: reorganize crates into layered directories`), those paths stopped lining up. `build.rs` silently fell through to the `None` variant, so every sidecar build — **local and the release CI** — shipped without lotus.

This is why #54's release (`app-v2026.6.17-rc1`) builds green but is still unusable: the placeholder is gone, but the sidecar is API-only (404 instead of exit-1).

## Fix

In `build-sidecar.cjs`, after staging, mirror `frontend_package/` into the `bamboo-server` crate dir so the compile-time `include_bytes!` actually picks it up. Self-contained binary, no runtime resource plumbing.

## Verification (local)

Rebuilt the sidecar with the fix and ran it directly:
- log: `Serving static files from .../frontend` (was `No embedded ... frontend package found; starting API-only server`)
- `GET /` → **200**, returns the lotus `<!doctype html>` (was 404)
- `GET /api/v1/health` → 200

## Follow-up

- Re-cut the release after this merges; **`app-v2026.6.17-rc1` is still broken** (API-only sidecar) and should be deleted/replaced.