### PR TITLE
chore: align lockfile package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bodhi-shell",
-  "version": "2026.4.24",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bodhi-shell",
-      "version": "2026.4.24",
+      "version": "0.0.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }


### PR DESCRIPTION
## Summary

- Align the root `package-lock.json` package version with `package.json`.
- Replace the stale `2026.4.24` lockfile metadata with the repository's current `0.0.0` placeholder version.

## Why

`package.json` moved to the `0.0.0` placeholder, but the two root package entries in `package-lock.json` were left at `2026.4.24`. Normal npm lockfile maintenance therefore dirties the checkout even when dependencies do not change.

## Test Plan

- `npm install --package-lock-only --ignore-scripts` (13 packages audited, 0 vulnerabilities)
- Verified `.version` and `.packages[""].version` both equal `package.json`'s version.
- `git diff --check`