### PR TITLE
feat: default local Bodhi builds to verified Lotus Next (#62)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Verify docs boundary
         run: node scripts/verify-boundaries.cjs docs-boundary
 
+      - name: Test local frontend and explicit package assembly boundaries
+        run: npm run test:build
+
       - name: Cache node_modules
         id: cache-node-modules-frontend
         uses: actions/cache@v5

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 .lotus-dist
+.bodhi-frontend
 .frontend-package
 dist-ssr
 *.local

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ It installs and runs as a real desktop app (Windows / macOS / Linux), with a glo
 | 🔔 Native notifications | Pushes desktop alerts through the system notification center |
 | 📋 Clipboard | Native clipboard writes (macOS / Windows) |
 | 🎨 Window theme | Follows the frontend to switch light/dark/system theme |
-| 📦 Splash-to-Lotus startup | Opens a bundled startup splash, waits for the managed Bamboo sidecar to become healthy, then loads the Lotus UI served by that sidecar |
+| 📦 Splash-to-Lotus Next startup | Opens a bundled splash, verifies the local frontend and managed Bamboo startup, then loads the packaged Lotus Next UI |
 | 🏢 Build modes | Internal builds show a confirmation dialog at startup; public builds boot straight in |
 
 ---
 
 ## Architecture
 
-Bodhi owns only the shell and the product surface — the desktop window, native integrations (clipboard, notifications, global shortcut), packaging and release. The UI comes from **Lotus**; the real execution engine is **Bamboo** (a local-first Rust agent runtime). Bodhi bundles a small `bodhi-splash` startup page, spawns the standalone `bamboo serve` binary as a managed Tauri sidecar, waits for that service to become healthy, and then navigates the release webview to the Lotus UI served by Bamboo. The shell does *not* link `bamboo-agent` as a crate dependency — `bamboo` is declared as an `externalBin` in `tauri.conf.json`.
+Bodhi owns the desktop window, native integrations (clipboard, notifications, global shortcut), packaging and release. Normal local builds use **Lotus Next** for the UI and **Bamboo** for the execution engine. Bodhi bundles a small `bodhi-splash` startup page, verifies the packaged frontend, and starts `bamboo serve --static-dir <owned-resource-directory>` as a managed Tauri sidecar. Once the owned backend is ready and serves the expected production index, the release webview navigates to it. The shell links no Bamboo crate; `bamboo` is declared as an `externalBin` in `tauri.conf.json`. The explicit published-package release path remains temporary legacy Lotus assembly as described below.
 
 ```mermaid
 graph TD
@@ -42,7 +42,7 @@ graph TD
     W["WebView<br/>starts on bundled bodhi-splash"]
     E["Managed sidecar<br/>bamboo serve externalBin<br/>127.0.0.1:9562"]
     N["Native commands<br/>clipboard · notifications<br/>window theme"]
-    E -- "after health: serve embedded Lotus" --> W
+    E -- "after owned startup: serve verified Lotus Next resources" --> W
     W -- "HTTP /api/v1/*" --> E
     W -- "Tauri IPC invoke" --> N
   end
@@ -52,7 +52,7 @@ graph TD
 **Where this sits in Zenith:**
 
 - **`bodhi`** — desktop AI product surface (this module)
-- **`lotus`** — the React + Vite UI layer
+- **`lotus-next`** — the canonical React + Vite UI layer for local builds
 - **`bamboo`** — the local-first Rust agent runtime (execution engine)
 - **`bodhi-server`** — Go backend: auth, persistence, billing+quota, LLM proxy
 - **`pavilion`** — official website & docs
@@ -78,12 +78,13 @@ Instead of linking and running the Bamboo HTTP server in-process, the shell spaw
 
 - **Bundled startup page**: Tauri's `frontendDist` is `../bodhi-splash`, not `.lotus-dist`. The webview stays on that local splash while the backend starts.
 - **Default port `9562`** (`DEFAULT_WEB_SERVICE_PORT`, defined in `src-tauri/src/lib.rs`).
-- **Reuse if the port is taken**: before spawning, it probes `http://127.0.0.1:9562/api/v1/health`; if a backend is already running (e.g. you manually started a standalone bamboo server), it **reuses it** instead of spawning its own, making it easy to debug frontend and backend independently.
-- **Health check and navigation**: after spawning, it polls `/api/v1/health` via `wait_for_health` for up to 60 seconds. Release builds then navigate the webview to the sidecar root, where Bamboo serves its embedded Lotus frontend. Debug builds keep Lotus's HMR `devUrl` unless `BODHI_SIDECAR_FRONTEND` is set.
+- **Owned local backend**: local source builds reject an occupied port before spawning. They neither reuse nor kill another listener; the error recommends a different `BODHI_BACKEND_PORT`.
+- **Health check and navigation**: local builds require the managed child's `Unified server running on http://127.0.0.1:<port>` output, emitted after Bamboo binds, then health and the expected index hash. Errors or termination stop startup. This existing producer signal is also checked during real desktop acceptance when updating Bamboo. Debug builds keep Lotus Next's HMR `devUrl` unless `BODHI_SIDECAR_FRONTEND` is set.
+- **Runtime endpoint**: the shell injects its numeric `__BAMBOO_BACKEND_PORT__` before any frontend module evaluates. Lotus Next's existing runtime uses it ahead of persisted browser endpoints; no machine-specific backend URL is compiled into the artifact.
 - **Crash-safe orphan guard**: the sidecar is spawned with `--parent-pid <shell_pid>`, so if the app dies *without* running cleanup (SIGKILL, force-quit, panic), the backend self-exits. On the clean path, `RunEvent::Exit` / `ExitRequested` kills the recorded child.
 - **No `bamboo-agent` crate dependency**: the shell links no Bamboo crate. `bamboo` is declared as an `externalBin` in `tauri.conf.json` (`"externalBin": ["binaries/bamboo"]`).
 
-> Why it matters: a user opens one app and the engine comes up with it; a developer can still run the backend externally for debugging. Best of both.
+The temporary explicit legacy package assembly retains its existing external-backend reuse behavior. Local source assembly always uses the owned-process checks above.
 
 ### Native desktop integrations
 
@@ -112,21 +113,34 @@ Per OS:
 
 Safety: the installer never overwrites a real file or a symlink it doesn't own (only links pointing at a bamboo inside a Bodhi install are refreshed); conflicts abort with a dialog naming the offending path. Re-running when already installed just reports "已安装,指向当前版本".
 
-### How Lotus reaches the packaged app
+### How Lotus Next reaches a local packaged app
 
-Bodhi contains only the startup splash; it does not carry a second copy of the product frontend. For a production sidecar build, `scripts/build-sidecar.cjs` runs Bamboo's frontend packaging step and embeds Lotus into the `bamboo` binary. The release workflow checks out the selected Bamboo ref, installs the selected `@bigduu/lotus` package into that checkout, and builds the sidecar in package mode.
+Bodhi consumes sibling `../lotus-next` and requires its package identity to be `@bigduu/lotus-next`. Every local production build runs Lotus Next's build and package-content checks, verifies the production index and asset-manifest references, and hashes every resource. `.bodhi-frontend/receipt.json` records the package name/version, Git revision, dirty-source flag, per-file SHA-256 hashes and a deterministic combined hash. A source revision or dirty-status change during the build aborts staging. Dirty checkouts remain usable and are labeled as dirty; the content hashes identify the actual artifact.
 
-`npm run web:build` still stages a Lotus dist in `.lotus-dist/` for CI/source verification. That directory is **not** Tauri's `frontendDist` and is not the production webview entrypoint. Source selection for staging and sidecar packaging uses:
+The verified dist is staged in `.lotus-dist/` for inspection and `.bodhi-frontend/dist/` for Tauri resources. Only the latter is bundled at `frontend/dist`; `frontendDist` remains the small splash. The executable pins the exact receipt at compilation and checks resource identity and all file hashes on startup. Missing files, changed bytes, unexpected files and symlinks fail visibly. The resolved resource directory is passed to Bamboo through its existing `--static-dir` option, so moving the app away from the checkout preserves startup. Local sidecars are compiled with `BAMBOO_FRONTEND_BUILD_MODE=api-only`, avoiding an additional legacy embedded UI.
+
+Before Tauri copies resources, the build script replaces only the generated `<Cargo profile>/frontend` directory, after validating its Cargo output ancestry. This prevents deleted hashed assets from surviving a later dev/build copy and falsely failing startup verification. Other build resources and any symlink targets are preserved.
+
+Local production artifacts explicitly clear `VITE_BACKEND_BASE_URL`, including values from frontend `.env` files. A nonempty value supplied by the caller is rejected. Lotus Next's own public-variable schema, bundle budgets and chunk-ownership checks remain authoritative.
 
 | Variable | Default | Description |
 |---|---|---|
-| `LOTUS_SOURCE` | `auto` | `auto` \| `local` \| `package`. `auto` prefers the local `../lotus`, otherwise uses the npm package |
-| `LOTUS_LOCAL_PATH` | `../lotus` | Local Lotus checkout path |
-| `LOTUS_PACKAGE_NAME` | `@bigduu/lotus` | Published Lotus npm package name |
+| `LOTUS_SOURCE` | `local` | Local Lotus Next source; `package` is an explicit temporary release-only path. `auto` is rejected |
+| `LOTUS_LOCAL_PATH` | `../lotus-next` | Lotus Next Git checkout root; missing or mismatched source fails without fallback |
+| `LOTUS_PACKAGE_NAME` | `@bigduu/lotus-next` for local builds | Package assembly requires the explicit value `@bigduu/lotus` |
+| `BAMBOO_LOCAL_PATH` | `../bamboo` | Source of the managed sidecar; required for local Tauri builds |
+
+### Temporary published-package release boundary
+
+CI/release jobs still explicitly select `LOTUS_SOURCE=package LOTUS_PACKAGE_NAME=@bigduu/lotus`. They install the chosen legacy Lotus package into Bodhi and Bamboo, stage and verify its dist, and run Bamboo's existing frontend packager with `BAMBOO_FRONTEND_BUILD_MODE=embedded`. Current Bamboo main produces a workspace-root `frontend_package`, while dev produces `crates/app/bamboo-server/frontend_package`. Bodhi requires both zip and manifest to be newly generated in exactly one layout, mirrors only a fresh root pair into the server crate, and rejects stale, partial or ambiguous output. The app bundles the assembly receipt only and keeps the existing embedded frontend behavior. A receipt for this path must match the one compiled into the executable; missing local resources can never select it.
+
+This distinction is removed when [Zenith #187](https://github.com/bigduu/Zenith/issues/187) completes the formal consumer/publication/release-train cutover. Local-default work does not publish Lotus Next, dispatch a release, archive legacy Lotus, or certify the broader root/child Jiandu persistence gate.
+
+Historical or manual Bamboo checkouts with either generated output directory as a symlink fail closed. Set `BAMBOO_LOCAL_PATH` to a clean checkout for package assembly; the existing link and its target are left untouched.
 
 ### Internal vs public build mode
 
-`is_internal_build_mode()` reads the compile-time `option_env!("BODHI_INTERNAL_BUILD")` or runtime `BODHI_INTERNAL_BUILD`. Internal builds show a startup confirmation dialog; public builds boot straight in. Frontend rebranding is driven by Lotus's rebrand scripts (`npm run rebrand:public` / `rebrand:internal`, proxied from `bodhi/package.json`).
+`is_internal_build_mode()` reads the compile-time `option_env!("BODHI_INTERNAL_BUILD")` or runtime `BODHI_INTERNAL_BUILD`. Internal builds show a startup confirmation dialog; public builds boot straight in. The normal public/internal Tauri variants select this shell mode without invoking legacy frontend rebranding. Existing `rebrand:*` utilities are legacy Lotus maintenance commands and are not part of local Lotus Next assembly.
 
 ---
 
@@ -138,7 +152,7 @@ Bodhi contains only the startup splash; it does not carry a second copy of the p
 - Node.js + npm (frontend toolchain)
 - Rust toolchain (Tauri backend)
 - a sibling `../bamboo` checkout for the real development sidecar
-- a sibling `../lotus` checkout for the HMR development frontend
+- a sibling `../lotus-next` checkout with dependencies installed (`npm ci` there)
 
 ### Develop
 
@@ -147,7 +161,7 @@ Bodhi contains only the startup splash; it does not carry a second copy of the p
 npm run tauri:dev
 ```
 
-`tauri:dev` follows `beforeDevCommand`: it builds a debug sidecar from sibling `../bamboo`, starts sibling `../lotus` with Vite HMR, and then launches the Tauri window at `devUrl: http://localhost:1420`. Development does not use `.lotus-dist` as the webview source.
+`tauri:dev` follows `beforeDevCommand`: it builds and verifies Lotus Next, stages its resources, builds an API-only debug sidecar from sibling `../bamboo`, and starts Lotus Next's Vite server on loopback port `1420` with strict-port behavior. The window uses `devUrl: http://localhost:1420` for HMR. The same verified resources are available when `BODHI_SIDECAR_FRONTEND` is set to exercise sidecar-served assets in a debug shell.
 
 Branded dev variants:
 
@@ -164,30 +178,35 @@ npm run tauri:build:public    # public-mode bundle
 npm run tauri:build:internal  # internal-mode bundle
 ```
 
-`tauri:build` runs `scripts/build-sidecar.cjs` through `beforeBuildCommand`. With a sibling Bamboo checkout, that script packages Lotus into a release-mode Bamboo sidecar; Tauri itself still bundles `bodhi-splash` as `frontendDist`. The release workflow performs the same assembly from an explicit Bamboo ref and Lotus package version for each target platform.
+`tauri:build` runs `scripts/build-sidecar.cjs` through `beforeBuildCommand`: verified Lotus Next resources plus a release-mode API-only Bamboo sidecar. Tauri bundles the splash, resources and executable. Bare `cargo build` still supports CI shell compilation with inert placeholders; those are not runnable local app assembly.
 
-### Stage Lotus assets for verification
+### Build or preview the selected frontend
 
 ```bash
-npm run web:build             # build/stage Lotus into .lotus-dist for verification
-npm run web:source:info       # print the current Lotus source (local/package + LOTUS_SOURCE)
+npm run web:build             # build, verify and stage Lotus Next
+npm run web:source:info       # report the selected source, or fail with guidance
+npm run dev                  # Lotus Next HMR on loopback :1420
+npm run preview              # build/verify, then preview Lotus Next on :1420
+npm run test:build            # focused source/artifact/assembly fixtures, no Cargo
 ```
 
-These commands do not change Tauri's `frontendDist`; the packaged app still starts from `bodhi-splash` and receives Lotus from the healthy sidecar.
+These commands keep Tauri's splash entrypoint unchanged. Preview and HMR commands require a local source checkout; dist-only release packages do not provide a development server.
 
 ### Run frontend & backend separately
 
-Because the sidecar reuses an existing backend if the port is already in use, you can run a standalone backend for debugging. The Bamboo backend entry point is the `serve` subcommand of the `bamboo` binary (in the `bamboo/` directory):
+For browser-only debugging, run the backend and Lotus Next directly. Do not launch local Bodhi against this occupied backend port; the desktop app owns its own engine and will report the collision.
 
 ```bash
 # Terminal 1: backend (in bamboo/)
 cargo run --bin bamboo -- serve --port 9562
 
-# Terminal 2: frontend (in lotus/)
+# Terminal 2: frontend (in lotus-next/)
 npm run dev
 ```
 
 Run `bamboo serve --help` for the current server options.
+
+For automated desktop acceptance, use a disposable `BAMBOO_DATA_DIR`, configuration and workspace, a separate WebView/app identifier and an unused `BODHI_BACKEND_PORT`. Enforce denial of access to the user's real `.bamboo` and `.jiandu` stores. Move the test bundle away from source checkouts, launch its actual WebView and managed Bamboo twice, verify the same artifact and local setting/session, and verify the child exits after each complete app exit. Do not install over the user's app or treat a browser mock as this acceptance test.
 
 ### Runtime diagnostic env vars
 
@@ -201,7 +220,7 @@ Run `bamboo serve --help` for the current server options.
 | `BODHI_BACKEND_PORT` | Override the sidecar backend port (default `9562`) |
 | `BODHI_SIDECAR_FRONTEND` | Force the webview to use the sidecar frontend in debug/dev builds |
 
-> Note: this module does NOT define `type-check` / `test:run` / `test:e2e` — those belong to **Lotus**. Bodhi's `package.json` only contains the web/rebrand/tauri scripts listed above.
+Frontend `type-check` / `test:run` / `test:e2e` belong to **Lotus Next**. Bodhi runs its focused `test:build` fixtures and the Rust shell tests.
 
 ---
 
@@ -209,7 +228,7 @@ Run `bamboo serve --help` for the current server options.
 
 | Module | Role | Link |
 |---|---|---|
-| **lotus** | React + Vite UI layer | [bigduu/Lotus](https://github.com/bigduu/Lotus) |
+| **lotus-next** | Canonical React + Vite UI for local builds | [bigduu/lotus-next](https://github.com/bigduu/lotus-next) |
 | **bamboo** | local-first Rust agent runtime | [bigduu/Bamboo-agent](https://github.com/bigduu/Bamboo-agent) |
 | **bodhi-server** | Go backend: auth / persistence / billing+quota / LLM proxy | [bigduu/bodhi-server](https://github.com/bigduu/bodhi-server) |
 | **pavilion** | official website & docs | [bigduu/Pavilion](https://github.com/bigduu/Pavilion) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,14 +27,14 @@ Bodhi AI 把 AI 从一个"聊天框"变成一台**会干活的桌面工作台**�
 | 🔔 系统通知 | 通过系统通知中心推送桌面提醒 |
 | 📋 系统剪贴板 | 原生剪贴板写入（macOS / Windows） |
 | 🎨 主题同步 | 跟随前端切换浅色/深色/系统主题 |
-| 📦 Splash 到 Lotus 启动链 | 先显示内置启动页，等待托管 Bamboo sidecar 健康，再加载由 sidecar 提供的 Lotus UI |
+| 📦 Splash 到 Lotus Next 启动链 | 先显示内置启动页，校验本地前端与托管 Bamboo 启动，再加载打包的 Lotus Next UI |
 | 🏢 内部/公开构建 | 内部构建启动时弹出确认对话框，公开构建直接进入 |
 
 ---
 
 ## 架构
 
-Bodhi 只负责“外壳”和“产品门面”：它拥有桌面窗口、原生集成（剪贴板、通知、全局快捷键）、打包与发布；前端 UI 由 **Lotus** 提供；真正的执行引擎是 **Bamboo**（Rust 本地优先 agent 运行时）。Bodhi 内置一个很小的 `bodhi-splash` 启动页，将独立的 `bamboo serve` 二进制作为托管 Tauri sidecar 拉起，等待服务健康后，再让 release webview 导航到由 Bamboo 提供的 Lotus UI。外壳**不**以 crate 依赖的形式链接 `bamboo-agent`——`bamboo` 在 `tauri.conf.json` 中声明为 `externalBin`。
+Bodhi 负责桌面窗口、原生集成（剪贴板、通知、全局快捷键）、打包与发布。普通本地构建默认使用 **Lotus Next** 前端和 **Bamboo** 执行引擎。应用先显示 `bodhi-splash`，校验包内前端，再通过 `bamboo serve --static-dir <应用资源目录>` 启动托管 sidecar。确认本次启动的引擎已经就绪且提供预期的生产首页后，release WebView 才导航过去。外壳不链接 Bamboo crate；`bamboo` 在 `tauri.conf.json` 中声明为 `externalBin`。显式 npm 包发布流程暂时保留旧 Lotus 组装方式，见下文发布边界。
 
 ```mermaid
 graph TD
@@ -42,7 +42,7 @@ graph TD
     W["WebView<br/>先显示内置 bodhi-splash"]
     E["Managed sidecar<br/>bamboo serve externalBin<br/>127.0.0.1:9562"]
     N["Native commands<br/>clipboard · notifications<br/>window theme"]
-    E -- "健康后提供内嵌 Lotus" --> W
+    E -- "确认本次启动后提供校验过的 Lotus Next 资源" --> W
     W -- "HTTP /api/v1/*" --> E
     W -- "Tauri IPC invoke" --> N
   end
@@ -52,7 +52,7 @@ graph TD
 **Zenith 全栈定位：**
 
 - **`bodhi`** — 桌面产品门面（Tauri 外壳，即本模块）
-- **`lotus`** — React + Vite 前端 UI 层
+- **`lotus-next`** — 本地构建默认的 React + Vite 前端 UI 层
 - **`bamboo`** — 本地优先 Rust agent 运行时（执行引擎）
 - **`bodhi-server`** — Go 后端：认证 / 持久化 / 计费配额 / LLM 代理
 - **`pavilion`** — 官网与文档
@@ -78,12 +78,13 @@ graph TD
 
 - **内置启动页**：Tauri 的 `frontendDist` 是 `../bodhi-splash`，不是 `.lotus-dist`。后端启动期间，webview 保持在这个本地 splash。
 - **默认端口 `9562`**（`DEFAULT_WEB_SERVICE_PORT`，定义在 `src-tauri/src/lib.rs`）。
-- **端口已占用则复用**：拉起前先探测 `http://127.0.0.1:9562/api/v1/health`；若已有后端在跑（例如你手动起了独立 bamboo server），则**直接复用**而不重复拉起，方便前后端独立调试。
-- **健康检查与导航**：拉起后通过 `wait_for_health` 轮询 `/api/v1/health`，最长 60 秒。release 构建随后把 webview 导航到 sidecar 根地址，由 Bamboo 提供内嵌的 Lotus 前端；debug 构建默认保留 Lotus HMR 的 `devUrl`，除非设置 `BODHI_SIDECAR_FRONTEND`。
+- **拥有自己的本地引擎**：本地源码构建会在启动前拒绝已占用端口，不复用或终止其他监听进程。错误提示会建议用 `BODHI_BACKEND_PORT` 选择其他端口。
+- **健康检查与导航**：本地构建先要求托管子进程输出 `Unified server running on http://127.0.0.1:<port>`；该日志在 Bamboo 成功绑定端口后才产生。然后检查健康状态与预期首页哈希。启动错误或子进程退出都会中止启动。升级 Bamboo 时，真实桌面验收也需要覆盖这个已有日志约定。debug 构建保留 Lotus Next HMR 的 `devUrl`，除非设置 `BODHI_SIDECAR_FRONTEND`。
+- **运行时地址**：外壳在任何前端模块执行前注入数字 `__BAMBOO_BACKEND_PORT__`。Lotus Next 的现有运行时优先使用它，避免浏览器曾保存的地址改变本次桌面后端；产物不编译机器专属后端地址。
 - **崩溃安全的孤儿守护**：sidecar 拉起时带 `--parent-pid <shell_pid>`，若应用异常死亡（SIGKILL、强制退出、panic），后端会自行退出。正常退出路径中，`RunEvent::Exit` / `ExitRequested` 会 kill 已记录的子进程。
 - **无 `bamboo-agent` crate 依赖**：外壳不链接任何 Bamboo crate。`bamboo` 在 `tauri.conf.json` 中声明为 `externalBin`（`"externalBin": ["binaries/bamboo"]`）。
 
-> 为什么重要：用户只需打开一个应用，引擎随之启动；同时开发者仍可在外部单独运行后端做调试——两全其美。
+临时保留的显式旧 Lotus 包发布流程仍沿用原来的外部服务复用行为。本地源码构建始终使用上述进程归属检查。
 
 ### 桌面原生集成
 
@@ -112,21 +113,34 @@ graph TD
 
 安全规则：绝不覆盖普通文件或不属于 Bodhi 的软链接（只会刷新指向 Bodhi 安装内 bamboo 的旧链接）;冲突时中止并在对话框中指明冲突路径。已安装时重复执行只提示「已安装,指向当前版本」。
 
-### Lotus 如何进入打包应用
+### Lotus Next 如何进入本地打包应用
 
-Bodhi 只包含启动 splash，不维护第二份产品前端。生产 sidecar 构建时，`scripts/build-sidecar.cjs` 会调用 Bamboo 的前端打包步骤，把 Lotus 嵌入 `bamboo` 二进制。release workflow 会检出指定的 Bamboo ref，把指定版本的 `@bigduu/lotus` 安装到该检出中，再以 package 模式构建 sidecar。
+Bodhi 默认读取同级 `../lotus-next`，并要求包名为 `@bigduu/lotus-next`。本地生产构建执行 Lotus Next 自身的 build 与 package-content 校验，再验证生产首页、asset-manifest 引用和所有文件哈希。`.bodhi-frontend/receipt.json` 记录包名、版本、Git 提交、源码是否有未提交改动、逐文件 SHA-256 和确定性的整体哈希。构建期间提交或脏状态变化会中止装配；允许从有改动的检出构建，但记录会明确标记 dirty，实际产物以文件哈希识别。
 
-`npm run web:build` 仍会把 Lotus dist 装配到 `.lotus-dist/`，用于 CI 与来源校验；该目录**不是** Tauri 的 `frontendDist`，也不是生产 webview 的入口。资产校验与 sidecar 打包通过以下变量选择来源：
+校验后的 dist 同时装配到 `.lotus-dist/`（便于检查）和 `.bodhi-frontend/dist/`（Tauri 资源）。仅后者以 `frontend/dist` 打包；`frontendDist` 仍是小型启动页。外壳在编译时固定校验记录，启动时核对包内记录及所有文件；缺失、损坏、多余文件或符号链接都会产生可见失败。应用把自己解析出的资源目录通过现有 `--static-dir` 参数交给 Bamboo，因此应用移离源码目录后仍可启动。本地 sidecar 强制以 `BAMBOO_FRONTEND_BUILD_MODE=api-only` 编译，避免额外内嵌旧 UI。
+
+Tauri 复制资源前，构建脚本先验证 Cargo 输出路径层级，再只替换生成的 `<Cargo profile>/frontend` 目录。这样连续 dev/build 不会保留上一次已经删除的哈希资源，避免正常重建被启动校验误判为损坏；其他构建资源和符号链接目标均保留。
+
+本地生产构建显式清空 `VITE_BACKEND_BASE_URL`，也覆盖前端 `.env` 文件中的地址；调用方若直接设置非空值，则报错并要求改用运行时端口。Lotus Next 自身的公共变量规则、产物大小与分包校验继续生效。
 
 | 变量 | 默认 | 说明 |
 |---|---|---|
-| `LOTUS_SOURCE` | `auto` | `auto` \| `local` \| `package`。`auto` 优先用本地 `../lotus`，否则用 npm 包 |
-| `LOTUS_LOCAL_PATH` | `../lotus` | 本地 Lotus 检出路径 |
-| `LOTUS_PACKAGE_NAME` | `@bigduu/lotus` | 已发布的 Lotus npm 包名 |
+| `LOTUS_SOURCE` | `local` | 默认使用本地 Lotus Next；`package` 是显式的临时发布流程，`auto` 被拒绝 |
+| `LOTUS_LOCAL_PATH` | `../lotus-next` | Lotus Next Git 检出根目录；缺失或身份不符时停止，不自动回退 |
+| `LOTUS_PACKAGE_NAME` | 本地为 `@bigduu/lotus-next` | package 发布装配必须显式设置为 `@bigduu/lotus` |
+| `BAMBOO_LOCAL_PATH` | `../bamboo` | 托管 sidecar 源码路径；本地 Tauri 构建必须提供真实检出 |
+
+### 临时的已发布包边界
+
+CI/release 仍显式设置 `LOTUS_SOURCE=package LOTUS_PACKAGE_NAME=@bigduu/lotus`，把选定的旧 Lotus 包安装到 Bodhi 和 Bamboo，校验 dist，再调用 Bamboo 现有打包脚本并强制 `BAMBOO_FRONTEND_BUILD_MODE=embedded`。当前 Bamboo main 输出根目录 `frontend_package`，dev 输出 `crates/app/bamboo-server/frontend_package`。Bodhi 要求恰好一个位置同时重新生成 zip 和 manifest；只有新生成的根目录文件对才会被复制到 server crate，旧产物、半成品和多个位置同时更新都会被拒绝。该模式只额外打包组装记录，保留旧 UI 内嵌行为。记录必须匹配编译时的内容，本地产物缺失不会切换到这个模式。
+
+待 [Zenith #187](https://github.com/bigduu/Zenith/issues/187) 完成正式消费者、产物发布与 release-train 切换后，移除此临时区分。本地默认构建工作不发布 Lotus Next、不触发 release、不归档旧 Lotus，也不宣称完成更广泛的根/子 agent Jiandu 持久化验收。
+
+历史或手动 Bamboo 检出若把任一生成目录设为符号链接，package 组装会明确失败。请把 `BAMBOO_LOCAL_PATH` 指向干净检出；原有链接及其目标均保持不变。
 
 ### 内部 / 公开构建模式
 
-`src-tauri/src/lib.rs` 中 `is_internal_build_mode()` 读取编译期 `option_env!("BODHI_INTERNAL_BUILD")` 或运行期 `BODHI_INTERNAL_BUILD` 环境变量。内部构建在启动时弹出确认对话框（"This is an internal development build…"），公开构建直接进入。前端品牌相关开关由 Lotus 的 rebrand 脚本驱动（`npm run rebrand:public` / `rebrand:internal`，已在 `bodhi/package.json` 透传）。
+`is_internal_build_mode()` 读取编译期 `option_env!("BODHI_INTERNAL_BUILD")` 或运行期环境变量。内部构建启动时弹出确认对话框，公开构建直接进入。普通 public/internal Tauri 入口仅选择外壳模式，不调用旧前端品牌脚本。现有 `rebrand:*` 是旧 Lotus 的维护工具，不属于本地 Lotus Next 组装路径。
 
 ---
 
@@ -138,7 +152,7 @@ Bodhi 只包含启动 splash，不维护第二份产品前端。生产 sidecar �
 - Node.js + npm（前端工具链）
 - Rust toolchain（Tauri 后端）
 - 同级 `../bamboo` 检出，用于构建真实的开发 sidecar
-- 同级 `../lotus` 检出，用于 HMR 开发前端
+- 同级 `../lotus-next` 检出，并在该目录执行 `npm ci` 安装依赖
 
 ### 开发
 
@@ -147,7 +161,7 @@ Bodhi 只包含启动 splash，不维护第二份产品前端。生产 sidecar �
 npm run tauri:dev
 ```
 
-`tauri:dev` 按 `beforeDevCommand` 依次从同级 `../bamboo` 构建 debug sidecar、用 Vite HMR 启动同级 `../lotus`，再在 `devUrl: http://localhost:1420` 打开 Tauri 窗口。开发模式不会把 `.lotus-dist` 作为 webview 来源。
+`tauri:dev` 按 `beforeDevCommand` 构建并校验 Lotus Next、装配资源、从同级 Bamboo 编译 API-only debug sidecar，再在回环地址端口 `1420` 启动 Lotus Next Vite，端口冲突会失败。窗口使用 `devUrl: http://localhost:1420` 提供 HMR；设置 `BODHI_SIDECAR_FRONTEND` 后，也可在 debug 外壳中检验 sidecar 提供的同一份生产资源。
 
 带品牌模式的开发：
 
@@ -164,30 +178,35 @@ npm run tauri:build:public    # 公开模式打包
 npm run tauri:build:internal  # 内部模式打包
 ```
 
-`tauri:build` 通过 `beforeBuildCommand` 运行 `scripts/build-sidecar.cjs`。存在同级 Bamboo 检出时，该脚本会把 Lotus 打包进 release 模式的 Bamboo sidecar；Tauri 自身仍以 `bodhi-splash` 作为 `frontendDist`。release workflow 则针对每个目标平台，从明确的 Bamboo ref 与 Lotus package 版本完成同样的装配。
+`tauri:build` 通过 `beforeBuildCommand` 运行 `scripts/build-sidecar.cjs`，得到经过校验的 Lotus Next 资源和 release 模式的 API-only Bamboo。Tauri 将启动页、资源和可执行文件一起打包。单独 `cargo build` 仍允许 CI 使用无功能占位文件检查外壳编译，但它不构成可运行的本地应用组装。
 
-### 装配 Lotus 资产用于校验
+### 构建或预览前端
 
 ```bash
-npm run web:build             # 构建/装配 Lotus 到 .lotus-dist，用于校验
-npm run web:source:info       # 打印当前 Lotus 来源（local/package + LOTUS_SOURCE）
+npm run web:build             # 构建、校验并装配 Lotus Next
+npm run web:source:info       # 显示选定来源，缺失时给出错误指引
+npm run dev                  # 回环地址 :1420 的 Lotus Next HMR
+npm run preview              # 构建、校验后在 :1420 预览 Lotus Next
+npm run test:build            # 来源、产物和组装测试，不调用 Cargo
 ```
 
-这些命令不会改变 Tauri 的 `frontendDist`；打包应用仍从 `bodhi-splash` 启动，并在 sidecar 健康后从 sidecar 获取 Lotus。
+这些命令保留 Tauri 的启动页入口。preview 和 HMR 需要本地源码；仅包含 dist 的发布包不提供开发服务器。
 
 ### 前后端独立调试
 
-由于 sidecar 在端口已被占用时会复用已有后端，你可以手动起独立后端来调试。Bamboo 后端的入口是 `bamboo` 二进制的 `serve` 子命令（在 `bamboo/` 目录）：
+仅通过浏览器调试时，可单独启动 Bamboo 与 Lotus Next。此时不要让本地 Bodhi 使用相同端口；桌面应用拥有自己的引擎，会报告端口占用。
 
 ```bash
 # 终端 1：后端（in bamboo/）
 cargo run --bin bamboo -- serve --port 9562
 
-# 终端 2：前端（in lotus/）
+# 终端 2：前端（in lotus-next/）
 npm run dev
 ```
 
 当前服务参数以 `bamboo serve --help` 为准。
+
+真实桌面自动验收应使用一次性的 `BAMBOO_DATA_DIR`、配置、工作区、独立 WebView/app identifier 和未占用的 `BODHI_BACKEND_PORT`，并强制禁止读取用户真实 `.bamboo`、`.jiandu` 目录。把测试应用移离源码检出，通过真实 WebView 和托管 Bamboo 启动两次，验证相同产物、本地设置或 session 的保留，并在每次完整退出后确认托管子进程已经消失。不要覆盖用户已安装应用，也不要用浏览器 mock 代替这个验收。
 
 ### 运行时诊断环境变量
 
@@ -201,7 +220,7 @@ npm run dev
 | `BODHI_BACKEND_PORT` | 覆盖 sidecar 后端端口（默认 `9562`） |
 | `BODHI_SIDECAR_FRONTEND` | 在 debug/dev 构建中强制 webview 使用 sidecar 前端 |
 
-> ⚠️ 说明：本仓不提供 `npm run type-check` / `test:run` / `test:e2e` 这类脚本——这些属于 **Lotus**。Bodhi 的 `package.json` 只包含上面列出的 web/rebrand/tauri 脚本。
+前端 `type-check` / `test:run` / `test:e2e` 属于 **Lotus Next**。Bodhi 运行自己的 `test:build` 测试及 Rust 外壳测试。
 
 ---
 
@@ -209,7 +228,7 @@ npm run dev
 
 | 模块 | 角色 | 链接 |
 |---|---|---|
-| **lotus** | React + Vite 前端 UI 层 | [bigduu/Lotus](https://github.com/bigduu/Lotus) |
+| **lotus-next** | 本地构建默认的 React + Vite 前端 | [bigduu/lotus-next](https://github.com/bigduu/lotus-next) |
 | **bamboo** | 本地优先 Rust agent 运行时（执行引擎） | [bigduu/Bamboo-agent](https://github.com/bigduu/Bamboo-agent) |
 | **bodhi-server** | Go 后端：认证 / 持久化 / 计费配额 / LLM 代理 | [bigduu/bodhi-server](https://github.com/bigduu/bodhi-server) |
 | **pavilion** | 官网与文档 | [bigduu/Pavilion](https://github.com/bigduu/Pavilion) |

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "dev": "npm run web:dev",
     "build": "npm run web:build",
-    "preview": "cd ../lotus && npm run preview",
-    "web:dev": "cd ../lotus && npm run dev",
+    "preview": "node scripts/web-build.cjs preview",
+    "web:dev": "node scripts/web-build.cjs dev",
     "web:build": "node scripts/web-build.cjs",
     "web:source:info": "node scripts/lotus-dist.cjs info",
+    "test:build": "node --test scripts/frontend.test.cjs",
     "build:sidecar": "node scripts/build-sidecar.cjs",
     "build:sidecar:dev": "node scripts/build-sidecar.cjs --debug",
     "rebrand:public": "cd ../lotus && npm run rebrand:public",
@@ -20,11 +21,11 @@
     "shell:rebrand:internal": "node scripts/rebrand-shell.cjs --target=internal",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:dev:public": "npm run rebrand:public && node scripts/tauri-mode.cjs --mode=public --target=dev",
-    "tauri:dev:internal": "npm run rebrand:internal && node scripts/tauri-mode.cjs --mode=internal --target=dev",
+    "tauri:dev:public": "node scripts/tauri-mode.cjs --mode=public --target=dev",
+    "tauri:dev:internal": "node scripts/tauri-mode.cjs --mode=internal --target=dev",
     "tauri:build": "tauri build",
-    "tauri:build:public": "npm run rebrand:public && node scripts/tauri-mode.cjs --mode=public --target=build",
-    "tauri:build:internal": "npm run rebrand:internal && node scripts/tauri-mode.cjs --mode=internal --target=build"
+    "tauri:build:public": "node scripts/tauri-mode.cjs --mode=public --target=build",
+    "tauri:build:internal": "node scripts/tauri-mode.cjs --mode=internal --target=build"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"

--- a/scripts/build-sidecar.cjs
+++ b/scripts/build-sidecar.cjs
@@ -6,29 +6,36 @@
  *   profile: --release (default) | --debug
  *   source : BAMBOO_SIDECAR_SOURCE = local (default when ../bamboo exists) | none
  *
- * For a release build it first (re)builds the embedded lotus frontend via bamboo's
- * own `frontend-package.cjs` (which honors LOTUS_SOURCE) so the sidecar serves a
- * fresh production lotus; a debug build reuses the existing embed, since `tauri dev`
- * uses lotus's own HMR dev server for the UI.
+ * Local source builds stage verified Lotus Next resources and compile an API-only
+ * sidecar. Explicit package releases retain Bamboo's existing embedded frontend
+ * until Zenith #187 completes the formal release consumer cutover.
  *
  * NOTE: `cargo build` on its own does NOT run this — Tauri's `build.rs` writes a
  * placeholder so the `externalBin` reference resolves (keeps a bare shell-compile,
  * e.g. CI, green). This script produces the *real* binary for `tauri build` / dev
  * and the zenith superproject release.
  */
-const { execSync } = require("child_process");
+const { execFileSync } = require("node:child_process");
 const fs = require("fs");
 const path = require("path");
+const { resolveSource } = require("./lotus-dist.cjs");
+const { buildFrontend } = require("./web-build.cjs");
 
 const BODHI = path.resolve(__dirname, "..");
 const BAMBOO = path.resolve(BODHI, process.env.BAMBOO_LOCAL_PATH || "../bamboo");
 const isDebug = process.argv.includes("--debug");
 const profile = isDebug ? "debug" : "release";
 
-const sh = (cmd, cwd) => execSync(cmd, { cwd, stdio: "inherit" });
+const frontend = resolveSource();
+buildFrontend(frontend);
+const buildEnv = {
+  ...process.env,
+  BAMBOO_FRONTEND_BUILD_MODE: frontend.mode === "local" ? "api-only" : "embedded",
+};
+const run = (command, args, cwd) => execFileSync(command, args, { cwd, env: buildEnv, stdio: "inherit" });
 
 function hostTriple() {
-  const m = execSync("rustc -vV", { encoding: "utf8" }).match(/host:\s*(\S+)/);
+  const m = execFileSync("rustc", ["-vV"], { encoding: "utf8" }).match(/host:\s*(\S+)/);
   if (!m) throw new Error("cannot determine host target triple from `rustc -vV`");
   return m[1];
 }
@@ -58,6 +65,9 @@ fs.mkdirSync(binDir, { recursive: true });
 const dest = path.join(binDir, `bamboo-${triple}${ext}`);
 
 if (SOURCE !== "local") {
+  if (frontend.mode === "local") {
+    throw new Error(`Local Bodhi needs a real Bamboo checkout at ${BAMBOO}. Set BAMBOO_LOCAL_PATH and rerun; a placeholder cannot serve Lotus Next.`);
+  }
   console.log(
     `ℹ️  BAMBOO_SIDECAR_SOURCE=${SOURCE}: no local ../bamboo checkout; keeping the build.rs ` +
       `placeholder (the real sidecar is assembled in the zenith superproject).`,
@@ -69,41 +79,56 @@ if (!bambooExists()) {
   process.exit(1);
 }
 
-if (!isDebug) {
+if (frontend.mode === "package" && !isDebug) {
   console.log("🔧 Building the embedded lotus frontend for the sidecar (production)…");
-  sh("node scripts/frontend-package.cjs", BAMBOO);
-
-  // frontend-package.cjs stages the package at the bamboo workspace ROOT
-  // (frontend_package/), but bamboo-server's build.rs embeds it from ITS OWN
-  // crate dir (CARGO_MANIFEST_DIR/frontend_package) via include_bytes!. Since the
-  // crates were reorganized under crates/app/, those paths no longer line up, so
-  // the embed silently resolves to None and the sidecar compiles as an API-only
-  // server with no UI — the webview then navigates to a 404 and the app hangs on
-  // the "Starting Bodhi…" splash. Mirror the staged package into the crate dir so
-  // the compile-time embed actually picks it up.
-  const stagedPkg = path.join(BAMBOO, "frontend_package");
+  // Published Bamboo main and dev currently use these two producer layouts.
+  // Observe which complete pair was actually regenerated, without deleting
+  // existing files or letting stale root output overwrite a fresh crate output.
+  const names = ["lotus-frontend.zip", "frontend-manifest.json"];
+  const rootPkg = path.join(BAMBOO, "frontend_package");
   const serverPkg = path.join(BAMBOO, "crates", "app", "bamboo-server", "frontend_package");
-  if (fs.existsSync(path.join(stagedPkg, "lotus-frontend.zip"))) {
-    fs.rmSync(serverPkg, { recursive: true, force: true });
-    fs.cpSync(stagedPkg, serverPkg, { recursive: true });
-    console.log(`✅ mirrored frontend package → ${path.relative(BAMBOO, serverPkg)}`);
-  } else {
-    console.warn(
-      `⚠️  no staged frontend package at ${stagedPkg}; sidecar will be API-only (no UI)`,
-    );
+  const layouts = [rootPkg, serverPkg];
+  const stamps = (dir) => {
+    try {
+      if (fs.lstatSync(dir).isSymbolicLink()) throw new Error(`Frontend package directory is a symlink: ${dir}. Set BAMBOO_LOCAL_PATH to a clean checkout; the existing link was left untouched.`);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    return names.map((name) => {
+    try {
+      const stat = fs.lstatSync(path.join(dir, name), { bigint: true });
+      if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`Invalid frontend package file: ${path.join(dir, name)}`);
+      return [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+    } catch (error) {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    }
+    });
+  };
+  const before = layouts.map(stamps);
+  run(process.execPath, ["scripts/frontend-package.cjs"], BAMBOO);
+  const after = layouts.map(stamps);
+  const changed = layouts.map((_, index) => index).filter((index) => after[index].some((stamp, file) => stamp !== before[index][file]));
+  if (changed.length !== 1 || after[changed[0]].some((stamp, file) => stamp === null || stamp === before[changed[0]][file])) {
+    throw new Error("Explicit package assembly must generate one fresh, complete zip/manifest pair; stale, partial or ambiguous outputs are refused.");
+  }
+  if (changed[0] === 0) {
+    fs.mkdirSync(serverPkg, { recursive: true });
+    for (const name of names) fs.copyFileSync(path.join(rootPkg, name), path.join(serverPkg, name));
+    console.log("✅ Mirrored fresh workspace-root frontend pair into bamboo-server");
   }
 }
 
-const targetFlag = isCross ? ` --target ${triple}` : "";
 console.log(
   `🔧 Building bamboo sidecar (${profile}${isCross ? `, cross → ${triple}` : ""}) from ${BAMBOO} …`,
 );
-sh(`cargo build --bin bamboo${isDebug ? "" : " --release"}${targetFlag}`, BAMBOO);
+run("cargo", ["build", "--locked", "--bin", "bamboo", ...(isDebug ? [] : ["--release"]), ...(isCross ? ["--target", triple] : [])], BAMBOO);
 
 // Cross builds land under target/<triple>/<profile>; host builds under target/<profile>.
+const targetDir = path.resolve(BAMBOO, process.env.CARGO_TARGET_DIR || "target");
 const built = isCross
-  ? path.join(BAMBOO, "target", triple, profile, `bamboo${ext}`)
-  : path.join(BAMBOO, "target", profile, `bamboo${ext}`);
+  ? path.join(targetDir, triple, profile, `bamboo${ext}`)
+  : path.join(targetDir, profile, `bamboo${ext}`);
 fs.copyFileSync(built, dest);
 if (!isWin) fs.chmodSync(dest, 0o755);
 

--- a/scripts/frontend.test.cjs
+++ b/scripts/frontend.test.cjs
@@ -1,0 +1,277 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vm = require("node:vm");
+const { execFileSync } = require("node:child_process");
+const { test } = require("node:test");
+const frontend = require("./lotus-dist.cjs");
+
+function write(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, typeof value === "string" ? value : JSON.stringify(value));
+}
+
+function fixture(t) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "bodhi-frontend-test-"));
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+  const root = path.join(temp, "bodhi");
+  const sourceRoot = path.join(temp, "lotus-next");
+  fs.mkdirSync(root);
+  write(path.join(sourceRoot, "package.json"), { name: frontend.NEXT_PACKAGE, version: "0.0.0" });
+  write(path.join(sourceRoot, ".gitignore"), "dist\n");
+  const git = (...args) => execFileSync("git", ["-C", sourceRoot, ...args], { stdio: "pipe" });
+  git("init");
+  git("add", ".");
+  git("-c", "user.name=Bodhi Test", "-c", "user.email=bodhi-test@example.invalid", "-c", "commit.gpgsign=false", "-c", "core.hooksPath=.no-hooks", "commit", "-m", "fixture");
+  write(path.join(sourceRoot, "dist/index.html"), '<html><script type="module" src="./assets/app.js"></script><link rel="stylesheet" href="./assets/app.css"></html>');
+  write(path.join(sourceRoot, "dist/assets/app.js"), 'import("./lazy.js");');
+  write(path.join(sourceRoot, "dist/assets/app.css"), "body { color: black; }");
+  write(path.join(sourceRoot, "dist/assets/lazy.js"), "export const lazy = true;");
+  write(path.join(sourceRoot, "dist/asset-manifest.json"), {
+    "index.html": { isEntry: true, file: "assets/app.js", css: ["assets/app.css"], dynamicImports: ["lazy"] },
+    lazy: { file: "assets/lazy.js" },
+  });
+  return { temp, root, sourceRoot, source: frontend.resolveSource({}, root) };
+}
+
+test("local default selects only sibling Lotus Next, even with legacy fallbacks available", (t) => {
+  const { root, sourceRoot, source, temp } = fixture(t);
+  assert.equal(source.mode, "local");
+  assert.equal(source.sourceRoot, sourceRoot);
+  write(path.join(temp, "lotus/package.json"), { name: frontend.LEGACY_PACKAGE, version: "1.0.0" });
+  write(path.join(root, "node_modules/@bigduu/lotus/package.json"), { name: frontend.LEGACY_PACKAGE, version: "1.0.0" });
+  fs.renameSync(sourceRoot, `${sourceRoot}-missing`);
+  assert.throws(() => frontend.resolveSource({}, root), /Lotus Next is missing.*LOTUS_LOCAL_PATH/);
+  assert.throws(() => frontend.resolveSource({ LOTUS_SOURCE: "auto" }, root), /automatic fallback was removed/);
+});
+
+test("wrong package identity or legacy local override fails closed", (t) => {
+  const { root, sourceRoot } = fixture(t);
+  assert.throws(() => frontend.resolveSource({ LOTUS_PACKAGE_NAME: frontend.LEGACY_PACKAGE }, root), /Local builds require/);
+  write(path.join(sourceRoot, "package.json"), { name: frontend.LEGACY_PACKAGE, version: "1.0.0" });
+  assert.throws(() => frontend.resolveSource({}, root), /identity mismatch/);
+});
+
+test("deterministic receipt records revision and dirty state without checkout addresses", (t) => {
+  const { root, sourceRoot, source } = fixture(t);
+  const first = frontend.stageDist(source, root);
+  const second = frontend.stageDist(source, root);
+  assert.deepEqual(first, second);
+  assert.match(first.sourceRevision, /^[a-f0-9]{40}$/);
+  assert.equal(first.sourceDirty, false);
+  assert.equal(first.contentHash, frontend.contentHash(frontend.inventory(path.join(root, ".bodhi-frontend/dist"))));
+  assert.equal(JSON.stringify(first).includes(sourceRoot), false);
+  write(path.join(sourceRoot, "new-source.ts"), "changed source");
+  const dirty = frontend.stageDist(source, root);
+  assert.equal(dirty.sourceDirty, true);
+  assert.equal(dirty.sourceRevision, first.sourceRevision);
+  write(path.join(sourceRoot, "dist/assets/lazy.js"), "export const lazy = false;");
+  assert.notEqual(frontend.stageDist(source, root).contentHash, first.contentHash);
+});
+
+test("local build binds the backend at runtime and overrides public .env addresses", (t) => {
+  const { source } = fixture(t);
+  assert.throws(() => frontend.localBuildEnvironment(source, { VITE_BACKEND_BASE_URL: "https://example.invalid" }), /runtime backend discovery/);
+  const env = frontend.localBuildEnvironment(source, {});
+  assert.equal(env.VITE_BACKEND_BASE_URL, "");
+  assert.match(env.VITE_APP_REVISION, /^[a-f0-9]{40}$/);
+});
+
+test("numeric root filenames use the same canonical UTF-8 order as Rust", (t) => {
+  const { root } = fixture(t);
+  const numbered = path.join(root, "numbered");
+  write(path.join(numbered, "2"), "two");
+  write(path.join(numbered, "10"), "ten");
+  const files = frontend.inventory(numbered);
+  assert.deepEqual(Object.keys(files), ["2", "10"]);
+  // Golden vector hashes UTF-8 `10\0<sha256(ten)>\n2\0<sha256(two)>\n`.
+  assert.equal(frontend.contentHash(files), "7b0c2eb6e494ca5000c68d513c21b0ce1cb1fff55b5077d0036c7ff62e951b3b");
+});
+
+test("a source revision change during production build prevents staging", (t) => {
+  const f = fixture(t);
+  const initial = frontend.sourceIdentity(f.source);
+  let staged = false;
+  let capturedRevision;
+  let revision = initial.sourceRevision;
+  const context = {
+    module: { exports: {} },
+    process: { env: {}, platform: process.platform },
+    require(name) {
+      if (name === "./lotus-dist.cjs") return {
+        ...frontend,
+        sourceIdentity: () => ({ ...initial, sourceRevision: revision }),
+        stageDist() { staged = true; },
+      };
+      if (name === "node:child_process") return {
+        spawnSync(_command, args, options) {
+          if (args.includes("build")) {
+            capturedRevision = options.env.VITE_APP_REVISION;
+            revision = "b".repeat(40);
+          }
+          return { status: 0 };
+        },
+      };
+      return require(name);
+    },
+  };
+  vm.runInNewContext(fs.readFileSync(path.join(__dirname, "web-build.cjs"), "utf8"), context);
+  assert.throws(() => context.module.exports.buildFrontend(f.source), /source revision or dirty status changed/);
+  assert.equal(capturedRevision, initial.sourceRevision);
+  assert.equal(staged, false);
+});
+
+test("missing, development or external entry assets are rejected", (t) => {
+  const { source, sourceRoot } = fixture(t);
+  for (const index of [
+    '<script type="module" src="/src/main.tsx"></script>',
+    '<script type="module" src="https://example.invalid/app.js"></script>',
+    '<script type="module" src="./assets/missing.js"></script>',
+    '<script type="module" src="../outside.js"></script>',
+  ]) {
+    write(path.join(sourceRoot, "dist/index.html"), index);
+    assert.throws(() => frontend.verifyDist(source));
+  }
+  fs.rmSync(path.join(sourceRoot, "dist/index.html"));
+  assert.throws(() => frontend.verifyDist(source), /index.html/);
+});
+
+test("published inline diagnostics and comments do not become fake asset references", (t) => {
+  const { source, sourceRoot } = fixture(t);
+  write(path.join(sourceRoot, "dist/index.html"), `
+    <!-- <script type="module" src="missing-comment.js"></script> -->
+    <script src="./assets/app.js" type=module></script>
+    <script>
+      setStatus("Bodhi UI is still loading. href=" + location.href + " module=" + moduleSrc);
+      var example = '<img src="missing-script-string.png">';
+    </script>
+    <style>body::before { content: '<img src="missing-style-string.png">'; }</style>
+    <link rel="stylesheet" href="./assets/app.css">
+  `);
+  assert.doesNotThrow(() => frontend.verifyDist(source));
+  assert.doesNotThrow(() => frontend.verifyDist({ ...source, mode: "package" }));
+  fs.rmSync(path.join(sourceRoot, "dist/assets/app.css"));
+  assert.throws(() => frontend.verifyDist(source), /assets\/app.css/);
+});
+
+test("missing lazy chunks, manifest edges and unsafe resource paths are rejected", (t) => {
+  const { source, sourceRoot } = fixture(t);
+  const lazy = path.join(sourceRoot, "dist/assets/lazy.js");
+  fs.rmSync(lazy);
+  assert.throws(() => frontend.verifyDist(source), /assets\/lazy.js/);
+  write(lazy, "export {};");
+  write(path.join(sourceRoot, "dist/asset-manifest.json"), {
+    "index.html": { isEntry: true, file: "assets/app.js", dynamicImports: ["missing"] },
+  });
+  assert.throws(() => frontend.verifyDist(source), /Missing asset manifest import/);
+  for (const file of ["../outside", "/absolute", "a\\b", "a//b", "a\0b", "C:/data"]) {
+    assert.equal(frontend.safeRelative(file), false);
+  }
+});
+
+test("symlinked frontend files are rejected", { skip: process.platform === "win32" }, (t) => {
+  const { source, sourceRoot } = fixture(t);
+  fs.symlinkSync(path.join(sourceRoot, "package.json"), path.join(sourceRoot, "dist/linked.json"));
+  assert.throws(() => frontend.verifyDist(source), /Unsafe frontend path/);
+});
+
+test("explicit legacy package staging remains supported without bundling a second UI", (t) => {
+  const { root, sourceRoot } = fixture(t);
+  const packageRoot = path.join(root, "node_modules/@bigduu/lotus");
+  write(path.join(packageRoot, "package.json"), { name: frontend.LEGACY_PACKAGE, version: "2026.9.0" });
+  fs.cpSync(path.join(sourceRoot, "dist"), path.join(packageRoot, "dist"), { recursive: true });
+  const source = frontend.resolveSource({ LOTUS_SOURCE: "package", LOTUS_PACKAGE_NAME: frontend.LEGACY_PACKAGE }, root);
+  const receipt = frontend.stageDist(source, root);
+  assert.equal(receipt.mode, "package");
+  assert.equal(receipt.sourceRevision, null);
+  assert.equal(fs.existsSync(path.join(root, ".lotus-dist/index.html")), true);
+  assert.deepEqual(fs.readdirSync(path.join(root, ".bodhi-frontend")), ["receipt.json"]);
+  assert.throws(() => frontend.resolveSource({ LOTUS_SOURCE: "package" }, root), /requires explicit/);
+});
+
+// Execute the real assembly script with instrumented process launches. All
+// filesystem work uses an isolated fixture; no Cargo or user checkout is touched.
+function assemble(f, mode, producerLayout = "crate") {
+  const bamboo = path.join(f.temp, "bamboo");
+  write(path.join(bamboo, "Cargo.toml"), "[workspace]\n");
+  const rootOutput = path.join(bamboo, "frontend_package");
+  const crateOutput = path.join(bamboo, "crates/app/bamboo-server/frontend_package");
+  if (mode === "package") {
+    for (const output of [rootOutput, crateOutput]) {
+      write(path.join(output, "lotus-frontend.zip"), "stale zip");
+      write(path.join(output, "frontend-manifest.json"), "stale manifest");
+    }
+    if (["symlink", "root-alias"].includes(producerLayout)) {
+      fs.rmSync(crateOutput, { recursive: true });
+      fs.symlinkSync(producerLayout === "root-alias" ? rootOutput : path.join(f.temp, "outside"), crateOutput, "dir");
+    }
+  }
+  const calls = [];
+  const source = mode === "local" ? f.source : { ...f.source, mode: "package", packageName: frontend.LEGACY_PACKAGE };
+  const env = { BAMBOO_LOCAL_PATH: bamboo, BAMBOO_FRONTEND_BUILD_MODE: producerLayout === "root" ? "api-only" : "auto" };
+  vm.runInNewContext(fs.readFileSync(path.join(__dirname, "build-sidecar.cjs"), "utf8"), {
+    __dirname: path.join(f.root, "scripts"),
+    console: { log() {}, warn() {}, error() {} },
+    process: { env, argv: ["node", "build-sidecar.cjs"], execPath: process.execPath },
+    require(name) {
+      if (name === "./lotus-dist.cjs") return { resolveSource: () => source };
+      if (name === "./web-build.cjs") return { buildFrontend: () => frontend.stageDist(source, f.root) };
+      if (name === "node:child_process") return {
+        execFileSync(command, args, options) {
+          if (command === "rustc") return "host: x86_64-unknown-linux-gnu\n";
+          calls.push({ command, args: [...args], env: { ...options.env } });
+          if (command === "cargo") write(path.join(bamboo, "target/release/bamboo"), "fixture binary");
+          else {
+            const outputs = producerLayout === "both" ? [rootOutput, crateOutput] :
+              producerLayout === "none" ? [] : [producerLayout === "root" ? rootOutput : crateOutput];
+            for (const output of outputs) {
+              write(path.join(output, "lotus-frontend.zip"), "explicit legacy embed");
+              if (producerLayout !== "partial") write(path.join(output, "frontend-manifest.json"), {});
+            }
+          }
+        },
+      };
+      return require(name);
+    },
+  });
+  return { calls, bamboo };
+}
+
+test("local sidecar assembly forces API-only and never invokes the legacy embed builder", (t) => {
+  const f = fixture(t);
+  const { calls, bamboo } = assemble(f, "local");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "cargo");
+  assert.equal(calls[0].env.BAMBOO_FRONTEND_BUILD_MODE, "api-only");
+  assert.ok(calls[0].args.includes("--locked"));
+  assert.equal(fs.existsSync(path.join(bamboo, "frontend_package")), false);
+  assert.equal(fs.readFileSync(path.join(f.root, "src-tauri/binaries/bamboo-x86_64-unknown-linux-gnu"), "utf8"), "fixture binary");
+});
+
+test("explicit package assembly accepts main/root and dev/crate producers without stale overwrites", (t) => {
+  for (const layout of ["root", "crate"]) {
+    const f = fixture(t);
+    const { calls, bamboo } = assemble(f, "package", layout);
+    assert.deepEqual(calls[0].args, ["scripts/frontend-package.cjs"]);
+    assert.equal(calls[1].command, "cargo");
+    assert.equal(calls[1].env.BAMBOO_FRONTEND_BUILD_MODE, "embedded");
+    assert.equal(fs.readFileSync(path.join(bamboo, "crates/app/bamboo-server/frontend_package/lotus-frontend.zip"), "utf8"), "explicit legacy embed");
+    if (layout === "crate") assert.equal(fs.readFileSync(path.join(bamboo, "frontend_package/lotus-frontend.zip"), "utf8"), "stale zip");
+  }
+});
+
+test("explicit package assembly rejects stale-only, partial and ambiguous producer output", (t) => {
+  for (const layout of ["none", "partial", "both"]) {
+    assert.throws(() => assemble(fixture(t), "package", layout), /one fresh, complete zip\/manifest pair/);
+  }
+});
+
+test("package assembly leaves an existing producer symlink untouched with actionable guidance", { skip: process.platform === "win32" }, (t) => {
+  for (const layout of ["symlink", "root-alias"]) {
+    const f = fixture(t);
+    assert.throws(() => assemble(f, "package", layout), /Set BAMBOO_LOCAL_PATH to a clean checkout/);
+    assert.equal(fs.lstatSync(path.join(f.temp, "bamboo/crates/app/bamboo-server/frontend_package")).isSymbolicLink(), true);
+    assert.equal(fs.readFileSync(path.join(f.temp, "bamboo/frontend_package/lotus-frontend.zip"), "utf8"), "stale zip");
+  }
+});

--- a/scripts/lotus-dist.cjs
+++ b/scripts/lotus-dist.cjs
@@ -1,137 +1,215 @@
 #!/usr/bin/env node
-
+// Bodhi's local source boundary. Published-package assembly stays explicit until
+// Zenith #187 completes the formal consumer cutover.
 const fs = require("node:fs");
 const path = require("node:path");
+const { createHash } = require("node:crypto");
+const { execFileSync } = require("node:child_process");
 
 const ROOT = path.resolve(__dirname, "..");
-const OUTPUT_DIST = path.join(ROOT, ".lotus-dist");
-const LOCAL_PATH = path.resolve(ROOT, process.env.LOTUS_LOCAL_PATH || "../lotus");
-const PACKAGE_NAME = process.env.LOTUS_PACKAGE_NAME || "@bigduu/lotus";
+const NEXT_PACKAGE = "@bigduu/lotus-next";
+const LEGACY_PACKAGE = "@bigduu/lotus";
+const RECEIPT = "receipt.json";
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
 
-function fail(message) {
-  console.error(`❌ ${message}`);
-  process.exit(1);
-}
-
-function dirExists(target) {
+function readJson(file) {
   try {
-    return fs.statSync(target).isDirectory();
-  } catch {
-    return false;
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new Error(`Cannot read ${file}: ${error.message}`);
   }
 }
 
-function localLotusExists() {
-  return dirExists(LOCAL_PATH) && fs.existsSync(path.join(LOCAL_PATH, "package.json"));
-}
-
-function resolvePackageRoot() {
-  try {
-    const pkgJsonPath = require.resolve(`${PACKAGE_NAME}/package.json`, {
-      paths: [ROOT],
-    });
-    return path.dirname(pkgJsonPath);
-  } catch {
-    return null;
+function resolveSource(env = process.env, root = ROOT) {
+  const mode = (env.LOTUS_SOURCE || "local").toLowerCase();
+  if (!["local", "package"].includes(mode)) {
+    throw new Error(`Invalid LOTUS_SOURCE=${mode}. Use local (default) or explicit package; automatic fallback was removed.`);
   }
-}
-
-function copyDist(sourceDist) {
-  if (!dirExists(sourceDist)) {
-    fail(`Lotus dist directory not found: ${sourceDist}`);
-  }
-
-  fs.rmSync(OUTPUT_DIST, { recursive: true, force: true });
-  fs.cpSync(sourceDist, OUTPUT_DIST, { recursive: true });
-  console.log(`✅ Synced Lotus dist: ${sourceDist} -> ${OUTPUT_DIST}`);
-}
-
-function resolveSource() {
-  const SOURCE_MODE = (process.env.LOTUS_SOURCE || "auto").toLowerCase();
-
-  if (!["auto", "local", "package"].includes(SOURCE_MODE)) {
-    fail(`Invalid LOTUS_SOURCE="${SOURCE_MODE}" (expected auto|local|package)`);
-  }
-
-  const localAvailable = localLotusExists();
-  const packageRoot = resolvePackageRoot();
-
-  if (SOURCE_MODE === "local") {
-    if (!localAvailable) {
-      fail(
-        `LOTUS_SOURCE=local but local Lotus not found at ${LOCAL_PATH}. ` +
-          "Set LOTUS_LOCAL_PATH or use LOTUS_SOURCE=package.",
-      );
+  let sourceRoot;
+  let packageName;
+  if (mode === "local") {
+    packageName = NEXT_PACKAGE;
+    if (env.LOTUS_PACKAGE_NAME && env.LOTUS_PACKAGE_NAME !== packageName) {
+      throw new Error(`Local builds require ${packageName}; remove LOTUS_PACKAGE_NAME=${env.LOTUS_PACKAGE_NAME}.`);
     }
-    return { mode: "local" };
-  }
-
-  if (SOURCE_MODE === "package") {
-    if (!packageRoot) {
-      fail(
-        `LOTUS_SOURCE=package but package "${PACKAGE_NAME}" is not installed. ` +
-          "Install it or use LOTUS_SOURCE=local.",
-      );
+    sourceRoot = path.resolve(root, env.LOTUS_LOCAL_PATH || "../lotus-next");
+    if (!fs.existsSync(path.join(sourceRoot, "package.json"))) {
+      throw new Error(`Lotus Next is missing at ${sourceRoot}. Check out sibling ../lotus-next or set LOTUS_LOCAL_PATH to its checkout.`);
     }
-    return { mode: "package", packageRoot };
-  }
-
-  if (localAvailable) {
-    return { mode: "local" };
-  }
-  if (packageRoot) {
-    return { mode: "package", packageRoot };
-  }
-
-  fail(
-    "No Lotus source found. Expected either:\n" +
-      `- local checkout at ${LOCAL_PATH}\n` +
-      `- installed package "${PACKAGE_NAME}"`,
-  );
-}
-
-function stageDist() {
-  const resolved = resolveSource();
-
-  if (resolved.mode === "local") {
-    console.log(`ℹ️ Using local Lotus at ${LOCAL_PATH}`);
-    copyDist(path.join(LOCAL_PATH, "dist"));
-    return;
-  }
-
-  console.log(`ℹ️ Using packaged Lotus "${PACKAGE_NAME}" at ${resolved.packageRoot}`);
-  copyDist(path.join(resolved.packageRoot, "dist"));
-}
-
-function printInfo() {
-  const localAvailable = localLotusExists();
-  const packageRoot = resolvePackageRoot();
-
-  console.log(`LOTUS_SOURCE=${(process.env.LOTUS_SOURCE || "auto").toLowerCase()}`);
-  console.log(`LOTUS_LOCAL_PATH=${LOCAL_PATH} (${localAvailable ? "found" : "missing"})`);
-  console.log(
-    `LOTUS_PACKAGE_NAME=${PACKAGE_NAME} (${packageRoot ? `found at ${packageRoot}` : "missing"})`,
-  );
-
-  if (localAvailable) {
-    console.log("Selected source (auto): local");
-  } else if (packageRoot) {
-    console.log("Selected source (auto): package");
   } else {
-    console.log("Selected source (auto): unavailable");
+    packageName = env.LOTUS_PACKAGE_NAME;
+    if (packageName !== LEGACY_PACKAGE) {
+      throw new Error(`The temporary release path requires explicit LOTUS_SOURCE=package LOTUS_PACKAGE_NAME=${LEGACY_PACKAGE}. Lotus Next package cutover belongs to Zenith #187.`);
+    }
+    try {
+      sourceRoot = path.dirname(require.resolve(`${packageName}/package.json`, { paths: [root] }));
+    } catch {
+      throw new Error(`Explicit release package ${packageName} is not installed. Install the selected release version in Bodhi.`);
+    }
+  }
+  const pkg = readJson(path.join(sourceRoot, "package.json"));
+  if (pkg.name !== packageName || typeof pkg.version !== "string" || !pkg.version) {
+    throw new Error(`Frontend identity mismatch at ${sourceRoot}: expected ${packageName} with a version.`);
+  }
+  return { mode, sourceRoot, packageName, version: pkg.version };
+}
+
+function sourceIdentity(source) {
+  if (source.mode === "package") return { sourceRevision: null, sourceDirty: false };
+  const git = (...args) => execFileSync("git", ["-C", source.sourceRoot, ...args], { encoding: "utf8" }).trim();
+  const sourceRevision = git("rev-parse", "HEAD");
+  if (!/^[a-f0-9]{40}$/.test(sourceRevision) || fs.realpathSync(git("rev-parse", "--show-toplevel")) !== fs.realpathSync(source.sourceRoot)) {
+    throw new Error("LOTUS_LOCAL_PATH must identify the Lotus Next Git checkout root.");
+  }
+  return { sourceRevision, sourceDirty: git("status", "--porcelain", "--untracked-files=normal") !== "" };
+}
+
+function localBuildEnvironment(source, env = process.env, identity = sourceIdentity(source)) {
+  if ((env.VITE_BACKEND_BASE_URL || "").trim()) {
+    throw new Error("Bodhi local artifacts require runtime backend discovery. Unset VITE_BACKEND_BASE_URL; use BODHI_BACKEND_PORT when launching the app.");
+  }
+  return {
+    ...env,
+    // Explicitly override .env files too. Lotus Next's public-variable schema
+    // still rejects every other unexpected VITE_* input during its own build.
+    VITE_BACKEND_BASE_URL: "",
+    VITE_APP_REVISION: identity.sourceRevision,
+    VITE_APP_VERSION: source.version,
+  };
+}
+
+function safeRelative(file) {
+  return typeof file === "string" && file.length > 0 &&
+    !/[\\:\x00-\x1f\x7f]/.test(file) &&
+    file.split("/").every((part) => part && part !== "." && part !== "..");
+}
+
+function inventory(dist) {
+  const files = {};
+  function visit(dir, prefix = "") {
+    if (fs.lstatSync(dir).isSymbolicLink()) throw new Error(`Frontend symlink is not allowed: ${dir}`);
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const name = prefix + entry.name;
+      const target = path.join(dir, entry.name);
+      if (!safeRelative(name) || entry.isSymbolicLink()) throw new Error(`Unsafe frontend path: ${name}`);
+      if (entry.isDirectory()) visit(target, `${name}/`);
+      else if (entry.isFile()) files[name] = sha256(fs.readFileSync(target));
+      else throw new Error(`Frontend resource is not a regular file: ${name}`);
+    }
+  }
+  visit(dist);
+  return Object.fromEntries(Object.entries(files).sort(([a], [b]) => Buffer.compare(Buffer.from(a), Buffer.from(b))));
+}
+
+function contentHash(files) {
+  // Object enumeration reorders integer-like keys even after fromEntries was
+  // sorted. Sort here too, matching Rust's BTreeMap UTF-8 filename ordering.
+  return sha256(Object.entries(files)
+    .sort(([a], [b]) => Buffer.compare(Buffer.from(a), Buffer.from(b)))
+    .map(([name, hash]) => `${name}\0${hash}\n`).join(""));
+}
+
+// Read actual opening tags. Inline diagnostics can contain strings such as
+// 'href=" + location.href'; those are JavaScript text, never asset references.
+function openingTags(html) {
+  const tags = [];
+  const token = /<!--[\s\S]*?(?:-->|$)|<([a-z][\w:-]*)\b((?:"[^"]*"|'[^']*'|[^'"<>])*)>/gi;
+  let match;
+  while ((match = token.exec(html))) {
+    if (!match[1]) continue;
+    const name = match[1].toLowerCase();
+    const attrs = Object.create(null);
+    for (const attr of match[2].matchAll(/(?:^|\s)([\w:-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g)) {
+      const key = attr[1].toLowerCase();
+      if (!Object.hasOwn(attrs, key)) attrs[key] = attr[2] ?? attr[3] ?? attr[4];
+    }
+    tags.push({ name, attrs });
+    if (["script", "style", "textarea", "title"].includes(name)) {
+      const closing = new RegExp(`</${name}\\s*>`, "gi");
+      closing.lastIndex = token.lastIndex;
+      token.lastIndex = closing.exec(html) ? closing.lastIndex : html.length;
+    }
+  }
+  return tags;
+}
+
+function verifyDist(source, dist = path.join(source.sourceRoot, "dist")) {
+  const files = inventory(dist);
+  const required = (name) => {
+    if (!safeRelative(name) || !Object.hasOwn(files, name)) throw new Error(`Missing or invalid frontend asset: ${name}`);
+  };
+  required("index.html");
+  const html = fs.readFileSync(path.join(dist, "index.html"), "utf8");
+  const tags = openingTags(html);
+  const modules = tags.filter((tag) => tag.name === "script" && tag.attrs.type?.toLowerCase() === "module" && tag.attrs.src);
+  if (modules.length === 0 || modules.some(({ attrs }) => /@vite\/client|^(?:\.\/|\/)?src\/|\.tsx?(?:$|[?#])/i.test(attrs.src))) {
+    throw new Error("Frontend index.html must reference a built production module, not a Vite development entry.");
+  }
+  for (const tag of tags) {
+    const reference = tag.name === "link" ? tag.attrs.href : tag.attrs.src;
+    if (!reference || (tag.name !== "script" && /^(?:data:|#)/.test(reference))) continue;
+    if (/^(?:[a-z]+:|\/\/)/i.test(reference)) throw new Error("Frontend entry assets must be packaged locally.");
+    const decoded = decodeURIComponent(reference.split(/[?#]/, 1)[0]);
+    required(decoded.replace(/^(?:\.\/|\/)/, ""));
+  }
+  if (source.mode === "local") {
+    required("asset-manifest.json");
+    const manifest = readJson(path.join(dist, "asset-manifest.json"));
+    if (!manifest["index.html"]?.isEntry) throw new Error("Frontend asset manifest has no production index entry.");
+    for (const record of Object.values(manifest)) {
+      required(record.file);
+      for (const key of ["css", "assets"]) {
+        if (record[key] !== undefined && !Array.isArray(record[key])) throw new Error(`Invalid asset manifest ${key}.`);
+        for (const file of record[key] || []) required(file);
+      }
+      for (const key of ["imports", "dynamicImports"]) {
+        if (record[key] !== undefined && !Array.isArray(record[key])) throw new Error(`Invalid asset manifest ${key}.`);
+        for (const imported of record[key] || []) {
+          if (typeof imported !== "string" || !Object.hasOwn(manifest, imported)) throw new Error(`Missing asset manifest import: ${imported}`);
+        }
+      }
+    }
+  }
+  return files;
+}
+
+function stageDist(source, root = ROOT, identity = sourceIdentity(source)) {
+  const dist = path.join(source.sourceRoot, "dist");
+  const files = verifyDist(source, dist);
+  const receipt = {
+    schemaVersion: 1,
+    mode: source.mode,
+    packageName: source.packageName,
+    version: source.version,
+    ...identity,
+    contentHash: contentHash(files),
+    files,
+  };
+  const output = path.join(root, ".lotus-dist");
+  const resource = path.join(root, ".bodhi-frontend");
+  // Only generated outputs are replaced. Verification failure exits the build
+  // before Tauri packaging, without minting a new receipt.
+  for (const target of [output, resource]) {
+    fs.rmSync(target, { recursive: true, force: true });
+    fs.mkdirSync(target, { recursive: true });
+  }
+  fs.cpSync(dist, output, { recursive: true });
+  if (source.mode === "local") fs.cpSync(dist, path.join(resource, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(resource, RECEIPT), `${JSON.stringify(receipt)}\n`);
+  console.log(`Verified ${source.packageName} ${receipt.sourceRevision || source.version}${receipt.sourceDirty ? " (dirty source)" : ""}: sha256 ${receipt.contentHash}`);
+  return receipt;
+}
+
+module.exports = { ROOT, NEXT_PACKAGE, LEGACY_PACKAGE, RECEIPT, resolveSource, sourceIdentity, localBuildEnvironment, safeRelative, inventory, contentHash, verifyDist, stageDist };
+
+if (require.main === module) {
+  try {
+    const command = process.argv[2] || "stage";
+    if (command === "info") console.log(JSON.stringify(resolveSource(), null, 2));
+    else if (command === "stage") require("./web-build.cjs").buildFrontend();
+    else throw new Error(`Unknown command ${command}; use stage or info.`);
+  } catch (error) {
+    console.error(`Frontend: ${error.message}`);
+    process.exitCode = 1;
   }
 }
-
-const command = process.argv[2] || "stage";
-
-if (command === "stage") {
-  stageDist();
-  process.exit(0);
-}
-
-if (command === "info") {
-  printInfo();
-  process.exit(0);
-}
-
-fail(`Unknown command "${command}". Use one of: stage, info.`);

--- a/scripts/web-build.cjs
+++ b/scripts/web-build.cjs
@@ -1,35 +1,40 @@
 #!/usr/bin/env node
-/**
- * Frontend build entry point for Bodhi.
- *
- * Respects the `LOTUS_SOURCE` environment variable:
- * - `package`  → skip local build, stage dist from the installed npm package
- * - `local`    → build from the local `../lotus` checkout, then stage
- * - `auto`     → build locally if `../lotus` exists, otherwise fall back to package
- */
-const { execSync } = require("child_process");
-const path = require("path");
+const { spawnSync } = require("node:child_process");
+const { ROOT, resolveSource, sourceIdentity, localBuildEnvironment, stageDist } = require("./lotus-dist.cjs");
 
-const ROOT = path.resolve(__dirname, "..");
-const SOURCE = (process.env.LOTUS_SOURCE || "auto").toLowerCase();
+function runNpm(source, args, env) {
+  const result = spawnSync("npm", args, { cwd: source.sourceRoot, env, stdio: "inherit", shell: process.platform === "win32" });
+  if (result.error || result.status !== 0) throw new Error(`Frontend npm ${args.join(" ")} failed (${result.error?.message || result.status}).`);
+}
 
-function lotusLocalExists() {
-  const fs = require("fs");
-  const lotusDir = path.resolve(ROOT, process.env.LOTUS_LOCAL_PATH || "../lotus");
+function buildFrontend(source = resolveSource()) {
+  const identity = sourceIdentity(source);
+  if (source.mode === "local") {
+    runNpm(source, ["run", "build"], localBuildEnvironment(source, process.env, identity));
+    // Preserve Lotus Next's package, startup-budget and chunk-ownership gates.
+    runNpm(source, ["run", "package:contents"], process.env);
+    const after = sourceIdentity(source);
+    if (identity.sourceRevision !== after.sourceRevision || identity.sourceDirty !== after.sourceDirty) {
+      throw new Error("Lotus Next source revision or dirty status changed during the build. Rebuild from a stable checkout; no new artifact was staged.");
+    }
+  }
+  return stageDist(source, ROOT, identity);
+}
+
+module.exports = { buildFrontend };
+
+if (require.main === module) {
   try {
-    return fs.statSync(path.join(lotusDir, "package.json")).isFile();
-  } catch {
-    return false;
+    const command = process.argv[2] || "build";
+    const source = resolveSource();
+    if (command === "build") buildFrontend(source);
+    else if (["dev", "preview"].includes(command)) {
+      if (source.mode !== "local") throw new Error(`${command} requires a local Lotus Next checkout; published release packages contain dist only.`);
+      if (command === "preview") buildFrontend(source);
+      runNpm(source, ["run", command, "--", "--host", "127.0.0.1", "--port", "1420", "--strictPort", ...process.argv.slice(3)], localBuildEnvironment(source));
+    } else throw new Error(`Unknown command ${command}; use build, dev or preview.`);
+  } catch (error) {
+    console.error(`Frontend: ${error.message}`);
+    process.exitCode = 1;
   }
 }
-
-if (SOURCE !== "package" && lotusLocalExists()) {
-  const lotusDir = path.resolve(ROOT, process.env.LOTUS_LOCAL_PATH || "../lotus");
-  console.log(`\uD83D\uDD27 Building Lotus from local source at ${lotusDir}...`);
-  execSync("npm run build", { cwd: lotusDir, stdio: "inherit" });
-} else {
-  console.log(`\uD83D\uDCE6 LOTUS_SOURCE=${SOURCE}: skipping local build, staging from package`);
-}
-
-// Stage the dist directory (from local or package, as determined by LOTUS_SOURCE).
-execSync("node scripts/lotus-dist.cjs stage", { cwd: ROOT, stdio: "inherit" });

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,8 +1,34 @@
 use std::path::PathBuf;
 
+mod build_support;
+
 fn main() {
     ensure_sidecar_placeholder();
+    pin_frontend_receipt();
+    build_support::reset_frontend_destination(&PathBuf::from(std::env::var("OUT_DIR").unwrap()))
+        .expect("replace only the generated frontend resource directory before Tauri copies it");
     tauri_build::build()
+}
+
+/// Pin the selected assembly in the executable so a missing or changed resource
+/// can never switch a local build back to an old embedded frontend. Bare Cargo
+/// shell checks get an inert resource; real Tauri hooks must stage the frontend.
+fn pin_frontend_receipt() {
+    let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let resource = manifest.join("../.bodhi-frontend");
+    let receipt = resource.join("receipt.json");
+    println!("cargo:rerun-if-changed={}", receipt.display());
+    std::fs::create_dir_all(&resource).expect("create frontend resource directory");
+    let bytes = std::fs::read(&receipt).unwrap_or_else(|_| b"null".to_vec());
+    if !receipt.exists() {
+        std::fs::write(
+            resource.join("unassembled.txt"),
+            "Run npm run build:sidecar before packaging.\n",
+        )
+        .expect("write inert shell-check resource");
+    }
+    let output = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("frontend-receipt.json");
+    std::fs::write(output, bytes).expect("pin frontend receipt");
 }
 
 /// Tauri validates the `externalBin` sidecar at build time, so a bare `cargo build`
@@ -14,7 +40,11 @@ fn main() {
 fn ensure_sidecar_placeholder() {
     let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let target = std::env::var("TARGET").unwrap_or_default();
-    let ext = if target.contains("windows") { ".exe" } else { "" };
+    let ext = if target.contains("windows") {
+        ".exe"
+    } else {
+        ""
+    };
     let bin = manifest
         .join("binaries")
         .join(format!("bamboo-{target}{ext}"));

--- a/src-tauri/build_support.rs
+++ b/src-tauri/build_support.rs
@@ -1,0 +1,191 @@
+//! Replace only Tauri's generated frontend copy before its overlay-style copy.
+//! Shared with shell unit tests; this helper uses no build/runtime dependencies.
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+fn invalid(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
+pub fn reset_frontend_destination(out_dir: &Path) -> io::Result<PathBuf> {
+    // tauri-build 2.5.6 derives its copy destination with exactly three parents:
+    // <profile>/build/bodhi-<cargo-hash>/out -> <profile>. Check those directories
+    // before doing any removal; never accept a caller-supplied cleanup target.
+    if !out_dir.is_absolute()
+        || out_dir
+            .components()
+            .any(|part| matches!(part, Component::ParentDir | Component::CurDir))
+    {
+        return Err(invalid(
+            "OUT_DIR must be an absolute Cargo build output path",
+        ));
+    }
+    let ancestors = out_dir.ancestors().take(4).collect::<Vec<_>>();
+    if ancestors.len() != 4
+        || out_dir.file_name() != Some("out".as_ref())
+        || ancestors[2].file_name() != Some("build".as_ref())
+    {
+        return Err(invalid(
+            "OUT_DIR must end with <profile>/build/bodhi-<hash>/out",
+        ));
+    }
+    let package = ancestors[1]
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid("invalid Cargo package output directory"))?;
+    if !package
+        .strip_prefix("bodhi-")
+        .is_some_and(|hash| hash.len() >= 8 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        return Err(invalid(
+            "OUT_DIR does not belong to Bodhi's Cargo build script",
+        ));
+    }
+    let profile = ancestors[3];
+    if !profile
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            !name.is_empty()
+                && name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+        })
+    {
+        return Err(invalid("invalid Cargo profile directory"));
+    }
+    for directory in ancestors {
+        let metadata = std::fs::symlink_metadata(directory)?;
+        if !metadata.is_dir() || metadata.is_symlink() {
+            return Err(invalid(
+                "Cargo output/profile ancestry must contain real directories, not symlinks",
+            ));
+        }
+    }
+    let canonical_profile = profile.canonicalize()?;
+    if out_dir.canonicalize()? != canonical_profile.join("build").join(package).join("out") {
+        return Err(invalid(
+            "Cargo output ancestry changed while resolving resources",
+        ));
+    }
+    let destination = canonical_profile.join("frontend");
+    match std::fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.is_symlink() => {
+            // Unlink only the generated destination itself. A link's target may
+            // contain user data and must never be traversed or removed.
+            #[cfg(windows)]
+            {
+                use std::os::windows::fs::MetadataExt;
+                if metadata.file_attributes() & 0x10 != 0 {
+                    std::fs::remove_dir(&destination)?;
+                } else {
+                    std::fs::remove_file(&destination)?;
+                }
+            }
+            #[cfg(not(windows))]
+            std::fs::remove_file(&destination)?;
+        }
+        Ok(metadata) if metadata.is_dir() => std::fs::remove_dir_all(&destination)?,
+        Ok(metadata) if metadata.is_file() => std::fs::remove_file(&destination)?,
+        Ok(_) => return Err(invalid("generated frontend destination is a special file")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    std::fs::create_dir(&destination)?;
+    Ok(destination)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path().join("target/debug");
+        let out = profile.join("build/bodhi-0123456789abcdef/out");
+        std::fs::create_dir_all(&out).unwrap();
+        (temp, out, profile)
+    }
+
+    #[test]
+    fn repeated_copy_replaces_old_hashed_assets_without_touching_siblings() {
+        let (_temp, out, profile) = fixture();
+        std::fs::write(profile.join("other-resource.txt"), "preserve").unwrap();
+        let first = reset_frontend_destination(&out).unwrap();
+        std::fs::create_dir_all(first.join("dist/assets")).unwrap();
+        std::fs::write(first.join("dist/assets/app-old.js"), "old").unwrap();
+        std::fs::write(first.join("receipt.json"), "old receipt").unwrap();
+        let second = reset_frontend_destination(&out).unwrap();
+        std::fs::create_dir_all(second.join("dist/assets")).unwrap();
+        std::fs::write(second.join("dist/assets/app-new.js"), "new").unwrap();
+        std::fs::write(second.join("receipt.json"), "new receipt").unwrap();
+        assert!(!second.join("dist/assets/app-old.js").exists());
+        assert_eq!(
+            std::fs::read_to_string(second.join("dist/assets/app-new.js")).unwrap(),
+            "new"
+        );
+        assert_eq!(
+            std::fs::read_to_string(profile.join("other-resource.txt")).unwrap(),
+            "preserve"
+        );
+    }
+
+    #[test]
+    fn a_regular_file_at_the_generated_destination_is_replaced() {
+        let (_temp, out, profile) = fixture();
+        std::fs::write(profile.join("frontend"), "old generated file").unwrap();
+        assert!(reset_frontend_destination(&out).unwrap().is_dir());
+    }
+
+    #[test]
+    fn malformed_or_relative_output_paths_are_rejected_before_cleanup() {
+        let (_temp, out, profile) = fixture();
+        std::fs::write(profile.join("frontend"), "preserve").unwrap();
+        for candidate in [
+            profile.clone(),
+            out.with_file_name("other"),
+            profile.join("build/another-crate/out"),
+            PathBuf::from("target/debug/build/bodhi-0123456789abcdef/out"),
+        ] {
+            assert!(reset_frontend_destination(&candidate).is_err());
+            assert_eq!(
+                std::fs::read_to_string(profile.join("frontend")).unwrap(),
+                "preserve"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn destination_and_nested_symlinks_never_remove_their_targets() {
+        let (temp, out, profile) = fixture();
+        let outside = temp.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("keep.txt"), "preserve").unwrap();
+        std::os::unix::fs::symlink(&outside, profile.join("frontend")).unwrap();
+        let generated = reset_frontend_destination(&out).unwrap();
+        assert!(!std::fs::symlink_metadata(&generated).unwrap().is_symlink());
+        std::os::unix::fs::symlink(&outside, generated.join("nested")).unwrap();
+        reset_frontend_destination(&out).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(outside.join("keep.txt")).unwrap(),
+            "preserve"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_build_ancestry_is_rejected_before_cleanup() {
+        let (temp, out, profile) = fixture();
+        let borrowed = temp.path().join("borrowed-build");
+        std::fs::rename(profile.join("build"), &borrowed).unwrap();
+        std::os::unix::fs::symlink(&borrowed, profile.join("build")).unwrap();
+        std::fs::write(profile.join("frontend"), "preserve").unwrap();
+        assert!(reset_frontend_destination(&out).is_err());
+        assert_eq!(
+            std::fs::read_to_string(profile.join("frontend")).unwrap(),
+            "preserve"
+        );
+        assert!(borrowed.join("bodhi-0123456789abcdef/out").is_dir());
+    }
+}

--- a/src-tauri/src/frontend.rs
+++ b/src-tauri/src/frontend.rs
@@ -1,0 +1,293 @@
+//! Verified local frontend resources, owned by the installed application.
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager, Runtime};
+
+const COMPILED_RECEIPT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/frontend-receipt.json"));
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Receipt {
+    schema_version: u32,
+    mode: String,
+    package_name: String,
+    version: String,
+    source_revision: Option<String>,
+    source_dirty: bool,
+    content_hash: String,
+    files: BTreeMap<String, String>,
+}
+
+pub struct VerifiedFrontend {
+    pub static_dir: Option<PathBuf>,
+    pub index_hash: Option<String>,
+}
+
+pub fn is_local_build() -> bool {
+    serde_json::from_slice::<Receipt>(COMPILED_RECEIPT)
+        .map(|receipt| receipt.mode == "local")
+        .unwrap_or(false)
+}
+
+pub fn resolve<R: Runtime>(app: &AppHandle<R>) -> Result<VerifiedFrontend, String> {
+    let resources = app.path().resource_dir().map_err(|e| e.to_string())?;
+    verify_resource(&resources, COMPILED_RECEIPT)
+        .map_err(|e| format!("Frontend resources are unavailable or damaged: {e}. Rebuild this app with npm run tauri:build."))
+}
+
+pub fn hash_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn safe_relative(file: &str) -> bool {
+    !file.is_empty()
+        && !file
+            .chars()
+            .any(|c| c == '\\' || c == ':' || c.is_ascii_control())
+        && file
+            .split('/')
+            .all(|part| !part.is_empty() && part != "." && part != "..")
+}
+
+fn file_inventory(
+    root: &Path,
+    dir: &Path,
+    files: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    for entry in std::fs::read_dir(dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let target = entry.path();
+        let kind = entry.file_type().map_err(|e| e.to_string())?;
+        if kind.is_symlink() {
+            return Err(format!("frontend symlink {}", target.display()));
+        }
+        if kind.is_dir() {
+            file_inventory(root, &target, files)?;
+        } else if kind.is_file() {
+            let name = target
+                .strip_prefix(root)
+                .map_err(|e| e.to_string())?
+                .to_str()
+                .ok_or("non-UTF8 frontend path")?
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            if !safe_relative(&name) {
+                return Err(format!("unsafe frontend path {name}"));
+            }
+            files.insert(
+                name,
+                hash_bytes(&std::fs::read(target).map_err(|e| e.to_string())?),
+            );
+        } else {
+            return Err("frontend resource is not a regular file".into());
+        }
+    }
+    Ok(())
+}
+
+fn content_hash(files: &BTreeMap<String, String>) -> String {
+    let mut digest = Sha256::new();
+    for (name, hash) in files {
+        digest.update(name.as_bytes());
+        digest.update(b"\0");
+        digest.update(hash.as_bytes());
+        digest.update(b"\n");
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn owned_directory(path: &Path) -> Result<PathBuf, String> {
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|e| format!("{}: {e}", path.display()))?;
+    if !metadata.is_dir() || metadata.is_symlink() {
+        return Err(format!(
+            "not an owned frontend directory: {}",
+            path.display()
+        ));
+    }
+    path.canonicalize().map_err(|e| e.to_string())
+}
+
+fn verify_resource(resources: &Path, expected: &[u8]) -> Result<VerifiedFrontend, String> {
+    let root = owned_directory(&resources.join("frontend"))?;
+    let receipt_path = root.join("receipt.json");
+    if std::fs::symlink_metadata(&receipt_path)
+        .map_err(|e| e.to_string())?
+        .is_symlink()
+    {
+        return Err("frontend receipt is a symlink".into());
+    }
+    let bytes = std::fs::read(receipt_path).map_err(|e| e.to_string())?;
+    if bytes != expected {
+        return Err("frontend identity does not match this executable".into());
+    }
+    let receipt: Receipt = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+    if receipt.schema_version != 1
+        || receipt.version.is_empty()
+        || content_hash(&receipt.files) != receipt.content_hash
+    {
+        return Err("invalid frontend receipt".into());
+    }
+    let index_hash = receipt
+        .files
+        .get("index.html")
+        .ok_or("missing production index")?
+        .clone();
+    if receipt.mode == "package"
+        && receipt.package_name == "@bigduu/lotus"
+        && receipt.source_revision.is_none()
+        && !receipt.source_dirty
+    {
+        // Explicit release assembly retains the existing Bamboo embed. This
+        // exception is pinned at compilation, never inferred from missing files.
+        return Ok(VerifiedFrontend {
+            static_dir: None,
+            index_hash: None,
+        });
+    }
+    if receipt.mode != "local"
+        || receipt.package_name != "@bigduu/lotus-next"
+        || !receipt
+            .source_revision
+            .as_deref()
+            .is_some_and(|sha| sha.len() == 40 && sha.bytes().all(|c| c.is_ascii_hexdigit()))
+    {
+        return Err("expected a local @bigduu/lotus-next artifact with a source revision".into());
+    }
+    let dist = owned_directory(&root.join("dist"))?;
+    let mut files = BTreeMap::new();
+    file_inventory(&dist, &dist, &mut files)?;
+    if files != receipt.files {
+        return Err("frontend files do not match the verified content hashes".into());
+    }
+    log::info!(
+        "Verified frontend {} revision {} dirty={} content_sha256={} static_dir={}",
+        receipt.package_name,
+        receipt.source_revision.unwrap_or_default(),
+        receipt.source_dirty,
+        receipt.content_hash,
+        dist.display()
+    );
+    Ok(VerifiedFrontend {
+        static_dir: Some(dist),
+        index_hash: Some(index_hash),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_root_filenames_match_the_javascript_canonical_hash() {
+        let files = BTreeMap::from([
+            ("2".to_string(), hash_bytes(b"two")),
+            ("10".to_string(), hash_bytes(b"ten")),
+        ]);
+        assert_eq!(
+            content_hash(&files),
+            "7b0c2eb6e494ca5000c68d513c21b0ce1cb1fff55b5077d0036c7ff62e951b3b"
+        );
+    }
+
+    fn fixture() -> (tempfile::TempDir, Vec<u8>) {
+        let temp = tempfile::tempdir().unwrap();
+        let frontend = temp.path().join("frontend");
+        std::fs::create_dir_all(frontend.join("dist/assets")).unwrap();
+        std::fs::write(
+            frontend.join("dist/index.html"),
+            "<script type=\"module\" src=\"./assets/app.js\"></script>",
+        )
+        .unwrap();
+        std::fs::write(
+            frontend.join("dist/assets/app.js"),
+            "console.log('Lotus Next')",
+        )
+        .unwrap();
+        let mut files = BTreeMap::new();
+        file_inventory(&frontend.join("dist"), &frontend.join("dist"), &mut files).unwrap();
+        let receipt = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 1, "mode": "local", "packageName": "@bigduu/lotus-next", "version": "0.0.0",
+            "sourceRevision": "d8a77943ce9ef7486d0d141ec8ad313ac74bb610", "sourceDirty": false,
+            "contentHash": content_hash(&files), "files": files
+        })).unwrap();
+        std::fs::write(frontend.join("receipt.json"), &receipt).unwrap();
+        (temp, receipt)
+    }
+
+    #[test]
+    fn resolves_resources_after_bundle_is_moved() {
+        let (original, receipt) = fixture();
+        let moved = tempfile::tempdir().unwrap();
+        std::fs::rename(
+            original.path().join("frontend"),
+            moved.path().join("frontend"),
+        )
+        .unwrap();
+        let verified = verify_resource(moved.path(), &receipt).unwrap();
+        assert_eq!(
+            verified.static_dir.unwrap(),
+            moved.path().join("frontend/dist").canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_missing_changed_and_extra_assets() {
+        for change in ["missing", "changed", "extra"] {
+            let (temp, receipt) = fixture();
+            let asset = temp.path().join("frontend/dist/assets/app.js");
+            match change {
+                "missing" => std::fs::remove_file(asset).unwrap(),
+                "changed" => std::fs::write(asset, "old Lotus").unwrap(),
+                _ => std::fs::write(temp.path().join("frontend/dist/unexpected.js"), "extra")
+                    .unwrap(),
+            }
+            assert!(verify_resource(temp.path(), &receipt).is_err());
+        }
+    }
+
+    #[test]
+    fn missing_or_replaced_receipt_cannot_select_legacy_embed() {
+        let (temp, receipt) = fixture();
+        let file = temp.path().join("frontend/receipt.json");
+        std::fs::write(&file, "{\"mode\":\"package\"}").unwrap();
+        assert!(verify_resource(temp.path(), &receipt).is_err());
+        std::fs::remove_file(file).unwrap();
+        assert!(verify_resource(temp.path(), &receipt).is_err());
+    }
+
+    #[test]
+    fn explicit_compiled_package_assembly_remains_embedded() {
+        let (temp, receipt) = fixture();
+        let mut value: serde_json::Value = serde_json::from_slice(&receipt).unwrap();
+        value["mode"] = "package".into();
+        value["packageName"] = "@bigduu/lotus".into();
+        value["sourceRevision"] = serde_json::Value::Null;
+        let package = serde_json::to_vec(&value).unwrap();
+        std::fs::write(temp.path().join("frontend/receipt.json"), &package).unwrap();
+        std::fs::remove_dir_all(temp.path().join("frontend/dist")).unwrap();
+        assert!(verify_resource(temp.path(), &package)
+            .unwrap()
+            .static_dir
+            .is_none());
+        assert!(verify_resource(temp.path(), &receipt).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_symlinked_resources() {
+        let (temp, receipt) = fixture();
+        std::fs::rename(
+            temp.path().join("frontend/dist"),
+            temp.path().join("outside"),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(
+            temp.path().join("outside"),
+            temp.path().join("frontend/dist"),
+        )
+        .unwrap();
+        assert!(verify_resource(temp.path(), &receipt).is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,8 +10,12 @@ use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut}
 use tokio::time::sleep;
 
 pub mod app_settings;
+#[cfg(test)]
+#[path = "../build_support.rs"]
+mod build_support;
 pub mod cli_install;
 pub mod command;
+pub mod frontend;
 pub mod sidecar;
 
 /// Default port for the bamboo sidecar backend.
@@ -177,7 +181,45 @@ fn show_internal_startup_confirmation<R: Runtime>(app: &App<R>) {
         });
 }
 
+fn show_startup_failure<R: Runtime>(app: &tauri::AppHandle<R>, message: &str) {
+    log::error!("Bodhi failed to start: {message}");
+    if let Some(window) = app.get_webview_window("main") {
+        let encoded = serde_json::to_string(message).unwrap_or_default();
+        let _ = window.eval(format!(
+            "document.body.textContent = 'Bodhi failed to start\\n\\n' + {encoded}; document.body.style.cssText = 'white-space:pre-wrap;padding:32px;font:15px system-ui;color:#e0918a;background:#121416';"
+        ));
+    }
+    // This also remains visible if the splash hasn't finished loading yet.
+    app.dialog()
+        .message(message)
+        .title("Bodhi failed to start")
+        .kind(MessageDialogKind::Error)
+        .show(|_| {});
+}
+
+fn local_backend_initialization(port: u16) -> String {
+    // Installed before page modules evaluate, including after navigation. The
+    // existing Lotus Next runtime gives this trusted numeric port priority over
+    // a persisted browser endpoint; no machine address enters the built dist.
+    format!("window.__BAMBOO_BACKEND_PORT__ = {port};")
+}
+
 fn setup<R: Runtime>(app: &mut App<R>) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let frontend = match frontend::resolve(app.handle()) {
+        Ok(frontend) => frontend,
+        Err(error) => {
+            show_startup_failure(app.handle(), &error);
+            return Ok(());
+        }
+    };
+    let local = frontend.static_dir.is_some();
+    let port = web_service_port();
+    if local {
+        if let Err(error) = sidecar::require_available_port(port) {
+            show_startup_failure(app.handle(), &error);
+            return Ok(());
+        }
+    }
     let app_data_dir = app_settings::bamboo_dir();
     std::fs::create_dir_all(&app_data_dir)?;
     log::info!("App data dir: {:?}", app_data_dir);
@@ -186,69 +228,62 @@ fn setup<R: Runtime>(app: &mut App<R>) -> std::result::Result<(), Box<dyn std::e
     // WebService). The child is held in SidecarState and killed on app exit; it also
     // self-exits if this process dies uncleanly — see `sidecar` and the
     // `--parent-pid` orphan guard on `bamboo serve`.
-    let port = web_service_port();
     let data_dir = app_data_dir.clone();
-    app.manage(sidecar::SidecarState(std::sync::Mutex::new(None)));
+    app.manage(sidecar::SidecarState::default());
 
     let sidecar_app = app.handle().clone();
     tauri::async_runtime::spawn(async move {
-        // If a backend is already serving on the port (e.g. a dev `bamboo serve`),
-        // reuse it; otherwise spawn our own managed sidecar.
-        if sidecar::backend_already_running(port).await {
+        // Only the explicitly assembled legacy package retains external-server
+        // reuse until the formal release cutover. Local source builds always own
+        // the backend serving their verified resource directory.
+        let owned = if !local && sidecar::backend_already_running(port).await {
             log::info!("Backend already running on port {port}; reusing it");
+            None
         } else {
-            match sidecar::spawn(&sidecar_app, port, &data_dir) {
-                Ok(child) => {
-                    if let Some(state) = sidecar_app.try_state::<sidecar::SidecarState>() {
-                        *state.0.lock().unwrap() = Some(child);
-                    }
+            match sidecar::spawn(
+                &sidecar_app,
+                port,
+                &data_dir,
+                frontend.static_dir.as_deref(),
+            ) {
+                Ok(status) => {
                     log::info!("bamboo sidecar spawned on port {port}");
+                    Some(status)
                 }
-                Err(e) => log::error!("Failed to spawn bamboo sidecar: {}", e),
+                Err(error) => {
+                    show_startup_failure(&sidecar_app, &error);
+                    return;
+                }
             }
-        }
+        };
 
         // Once the backend is healthy, point the webview at it (the sidecar serves
         // lotus). Release always navigates; in dev (debug) we keep the dev server
         // unless BODHI_SIDECAR_FRONTEND forces the sidecar frontend (used in tests).
-        if sidecar::wait_for_health(port, 60).await {
-            let use_sidecar_frontend =
-                !cfg!(debug_assertions) || std::env::var("BODHI_SIDECAR_FRONTEND").is_ok();
-            if use_sidecar_frontend {
-                if let Some(win) = sidecar_app.get_webview_window("main") {
-                    match format!("http://127.0.0.1:{port}").parse::<tauri::Url>() {
-                        Ok(url) => match win.navigate(url) {
-                            Ok(()) => {
-                                log::info!("webview navigated to sidecar http://127.0.0.1:{port}")
-                            }
-                            Err(e) => log::error!("navigate to sidecar failed: {e}"),
-                        },
-                        Err(e) => log::error!("bad sidecar url: {e}"),
-                    }
-                }
-            }
-        } else {
-            log::error!("bamboo backend never became healthy on port {port}");
-            // The webview is still on the boot splash (bodhi-splash/index.html).
-            // Replace its "Starting Bodhi…" spinner with an error so the user sees
-            // a failure instead of an indefinite spinner. Logs live under the
-            // bamboo sidecar data dir.
+        if let Err(error) = sidecar::wait_for_health(
+            port,
+            60,
+            if local { owned.as_ref() } else { None },
+            frontend.index_hash.as_deref(),
+        )
+        .await
+        {
+            sidecar::kill(&sidecar_app);
+            show_startup_failure(&sidecar_app, &error);
+            return;
+        }
+        let use_sidecar_frontend =
+            !cfg!(debug_assertions) || std::env::var("BODHI_SIDECAR_FRONTEND").is_ok();
+        if use_sidecar_frontend {
             if let Some(win) = sidecar_app.get_webview_window("main") {
-                let js = format!(
-                    r#"
-                    (function () {{
-                      var wrap = document.querySelector('.wrap');
-                      if (!wrap) {{ wrap = document.body; }}
-                      wrap.innerHTML =
-                        "<div style='max-width:420px;text-align:center;font:13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#e0918a;'>" +
-                        "<div style='font-size:15px;margin-bottom:10px;'>Bodhi failed to start</div>" +
-                        "<div style='color:#9aa0a6;line-height:1.5;'>The local engine did not become ready on port {port} within 60s.<br/>Try restarting the app; if it persists, check the engine logs and report this.</div>" +
-                        "</div>";
-                    }})();
-                    "#
-                );
-                if let Err(e) = win.eval(&js) {
-                    log::warn!("failed to render startup-failure splash: {e}");
+                match format!("http://127.0.0.1:{port}").parse::<tauri::Url>() {
+                    Ok(url) => match win.navigate(url) {
+                        Ok(()) => {
+                            log::info!("webview navigated to sidecar http://127.0.0.1:{port}")
+                        }
+                        Err(e) => log::error!("navigate to sidecar failed: {e}"),
+                    },
+                    Err(e) => log::error!("bad sidecar url: {e}"),
                 }
             }
         }
@@ -329,6 +364,11 @@ pub fn run() {
     let fs_plugin = tauri_plugin_fs::init();
 
     tauri::Builder::default()
+        .append_invoke_initialization_script(if frontend::is_local_build() {
+            local_backend_initialization(web_service_port())
+        } else {
+            String::new()
+        })
         .plugin(fs_plugin)
         .plugin(dialog_plugin)
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -394,6 +434,14 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn local_runtime_gets_only_its_numeric_managed_port() {
+        assert_eq!(
+            super::local_backend_initialization(19562),
+            "window.__BAMBOO_BACKEND_PORT__ = 19562;"
+        );
+    }
+
     #[test]
     fn should_exit_when_main_window_requests_close() {
         assert!(super::should_exit_on_main_window_close("main", true));

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -14,7 +14,8 @@
 //!    is the half a naive sidecar misses — the reason a backend can outlive a
 //!    force-quit.
 
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tauri::{AppHandle, Manager, Runtime};
@@ -23,7 +24,60 @@ use tauri_plugin_shell::ShellExt;
 
 /// Holds the running sidecar child so the app-exit handler can kill it.
 /// `None` until the child is spawned (or if an external backend was reused).
-pub struct SidecarState(pub Mutex<Option<CommandChild>>);
+#[derive(Default)]
+pub struct SidecarState {
+    child: Mutex<Option<CommandChild>>,
+    exiting: AtomicBool,
+}
+
+/// 0 = starting, 1 = this child bound its HTTP listener, 2 = exited/error.
+#[derive(Clone, Default)]
+pub struct StartupStatus(Arc<AtomicU8>);
+
+pub fn require_available_port(port: u16) -> Result<(), String> {
+    if port == 0 {
+        return Err("BODHI_BACKEND_PORT must be between 1 and 65535".into());
+    }
+    std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port))
+        .map(drop)
+        .map_err(|_| format!("Port {port} is unavailable. Another local service may be using it. Launch Bodhi with a different BODHI_BACKEND_PORT; the existing service was left untouched."))
+}
+
+fn local_log_filter(existing: &str) -> String {
+    let baseline = if existing.trim().is_empty() {
+        "info"
+    } else {
+        existing
+    };
+    format!("{baseline},bamboo_server::server::entrypoints=info")
+}
+
+// Bamboo emits this line only after build_bind_listeners succeeds. Requiring
+// this owned pipe signal closes the preflight-bind/spawn race: another process's
+// HTTP health can never establish readiness for our child. Keep the exact
+// producer message covered by the local desktop acceptance when upgrading it.
+fn consume_output(buffer: &mut Vec<u8>, bytes: &[u8], port: u16, status: &StartupStatus) {
+    buffer.extend_from_slice(bytes);
+    while let Some(end) = buffer.iter().position(|byte| *byte == b'\n') {
+        let line = buffer.drain(..=end).collect::<Vec<_>>();
+        let line = String::from_utf8_lossy(&line);
+        if line
+            .split_once(&format!(
+                "Unified server running on http://127.0.0.1:{port}"
+            ))
+            .is_some_and(|(_, tail)| tail.trim().trim_end_matches("\x1b[0m").is_empty())
+        {
+            let _ = status
+                .0
+                .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst);
+        }
+        log::info!("[bamboo] {}", line.trim_end());
+    }
+    // A malformed, unbounded log line must not consume unbounded shell memory.
+    if buffer.len() > 16 * 1024 {
+        buffer.clear();
+    }
+}
 
 /// Probe whether a backend is already serving on `port` (e.g. a dev `bamboo
 /// serve` the developer started by hand). If so, we don't spawn our own.
@@ -37,89 +91,258 @@ pub async fn backend_already_running(port: u16) -> bool {
 }
 
 /// Poll the backend health endpoint until it returns success or `max_secs`
-/// elapses. Returns whether it became healthy.
-pub async fn wait_for_health(port: u16, max_secs: u64) -> bool {
+/// elapses. Local builds additionally require this child's bound signal and the
+/// exact verified production index; health from another listener is insufficient.
+pub async fn wait_for_health(
+    port: u16,
+    max_secs: u64,
+    owned: Option<&StartupStatus>,
+    index_hash: Option<&str>,
+) -> Result<(), String> {
     let url = format!("http://127.0.0.1:{port}/api/v1/health");
-    let client = reqwest::Client::new();
-    for _ in 0..(max_secs * 2) {
-        if let Ok(resp) = client.get(&url).timeout(Duration::from_secs(2)).send().await {
-            if resp.status().is_success() {
-                return true;
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(2))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let poll = async {
+        loop {
+            let state = owned
+                .map(|status| status.0.load(Ordering::SeqCst))
+                .unwrap_or(1);
+            if state == 2 {
+                return Err("The managed Bamboo process exited before startup completed. Check the engine logs and restart Bodhi.".into());
             }
+            if state == 1 {
+                if let Ok(resp) = client.get(&url).send().await {
+                    if resp.status().is_success() {
+                        if let Some(expected) = index_hash {
+                            let response = client
+                                .get(format!("http://127.0.0.1:{port}/index.html"))
+                                .send()
+                                .await
+                                .map_err(|e| e.to_string())?;
+                            if !response.status().is_success()
+                                || crate::frontend::hash_bytes(
+                                    &response.bytes().await.map_err(|e| e.to_string())?,
+                                ) != expected
+                            {
+                                return Err("The managed backend did not serve this app's verified Lotus Next index. Startup stopped.".into());
+                            }
+                        }
+                        if owned.is_some_and(|status| status.0.load(Ordering::SeqCst) != 1) {
+                            continue;
+                        }
+                        return Ok(());
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-    false
+    };
+    tokio::time::timeout(Duration::from_secs(max_secs), poll).await
+        .map_err(|_| format!("The local engine did not become ready on port {port} within {max_secs}s. Check its logs and restart Bodhi."))?
 }
 
-/// Spawn `bamboo serve` as a sidecar and return its child handle.
+/// Spawn `bamboo serve`, record its child handle, and return its startup state.
 ///
-/// IMPORTANT: the returned [`CommandChild`] is the *graceful* handle — keep it
-/// in [`SidecarState`] and kill it on app exit. The `--parent-pid` orphan guard
+/// IMPORTANT: [`CommandChild`] is held in [`SidecarState`] for app-exit cleanup.
+/// The `--parent-pid` orphan guard
 /// (wired below) is the crash-safe backstop for unclean exits where that kill
 /// never runs.
 pub fn spawn<R: Runtime>(
     app: &AppHandle<R>,
     port: u16,
     data_dir: &std::path::Path,
-) -> Result<CommandChild, String> {
-    let command = app
+    static_dir: Option<&std::path::Path>,
+) -> Result<StartupStatus, String> {
+    let state = app
+        .try_state::<SidecarState>()
+        .ok_or("missing sidecar state")?;
+    let mut recorded = state.child.lock().map_err(|e| e.to_string())?;
+    if state.exiting.load(Ordering::SeqCst) {
+        return Err("Bodhi is exiting".into());
+    }
+    let mut args = vec![
+        "serve".to_string(),
+        "--parent-pid".to_string(),
+        std::process::id().to_string(),
+        "--port".to_string(),
+        port.to_string(),
+        "--bind".to_string(),
+        "127.0.0.1".to_string(),
+        "--data-dir".to_string(),
+        data_dir.to_string_lossy().into_owned(),
+    ];
+    if let Some(dir) = static_dir {
+        args.extend([
+            "--static-dir".to_string(),
+            dir.to_string_lossy().into_owned(),
+        ]);
+    }
+    let mut command = app
         .shell()
         .sidecar("bamboo")
         .map_err(|e| format!("resolve bamboo sidecar: {e}"))?
-        .args([
-            "serve".to_string(),
-            // Crash-safe orphan guard: the backend exits if this shell process
-            // disappears (incl. SIGKILL / force-quit, which run no cleanup).
-            "--parent-pid".to_string(),
-            std::process::id().to_string(),
-            "--port".to_string(),
-            port.to_string(),
-            "--bind".to_string(),
-            "127.0.0.1".to_string(),
-            // Pin the sidecar to the same data dir the shell resolved, so both
-            // read/write the same config.json without the shell linking bamboo.
-            "--data-dir".to_string(),
-            data_dir.to_string_lossy().into_owned(),
-        ]);
+        .args(args)
+        .set_raw_out(true);
+    if static_dir.is_some() {
+        command = command.env(
+            "RUST_LOG",
+            local_log_filter(&std::env::var("RUST_LOG").unwrap_or_default()),
+        );
+    }
 
     let (mut rx, child) = command
         .spawn()
         .map_err(|e| format!("spawn bamboo sidecar: {e}"))?;
+    log::info!("Managed bamboo pid={} port={port}", child.pid());
+    *recorded = Some(child);
+    drop(recorded);
+    let status = StartupStatus::default();
+    let reader_status = status.clone();
 
     // Drain the event stream so the child's stdout/stderr pipe never fills and
     // blocks the backend, and surface its logs under our logger.
     tauri::async_runtime::spawn(async move {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
         while let Some(event) = rx.recv().await {
             match event {
-                CommandEvent::Stdout(bytes) | CommandEvent::Stderr(bytes) => {
-                    let line = String::from_utf8_lossy(&bytes);
-                    let line = line.trim_end();
-                    if !line.is_empty() {
-                        log::info!("[bamboo] {line}");
-                    }
+                CommandEvent::Stdout(bytes) => {
+                    consume_output(&mut stdout, &bytes, port, &reader_status)
                 }
-                CommandEvent::Error(err) => log::warn!("[bamboo] sidecar error: {err}"),
+                CommandEvent::Stderr(bytes) => {
+                    consume_output(&mut stderr, &bytes, port, &reader_status)
+                }
+                CommandEvent::Error(err) => {
+                    reader_status.0.store(2, Ordering::SeqCst);
+                    log::warn!("[bamboo] sidecar error: {err}");
+                }
                 CommandEvent::Terminated(payload) => {
+                    reader_status.0.store(2, Ordering::SeqCst);
                     log::warn!("[bamboo] sidecar terminated: {payload:?}");
                     break;
                 }
                 _ => {}
             }
         }
+        reader_status.0.store(2, Ordering::SeqCst);
     });
 
-    Ok(child)
+    Ok(status)
 }
 
 /// Kill the recorded sidecar, if any. Idempotent; safe to call on app exit.
 pub fn kill<R: Runtime>(app: &AppHandle<R>) {
     if let Some(state) = app.try_state::<SidecarState>() {
-        if let Ok(mut guard) = state.0.lock() {
+        state.exiting.store(true, Ordering::SeqCst);
+        if let Ok(mut guard) = state.child.lock() {
             if let Some(child) = guard.take() {
                 log::info!("Killing bamboo sidecar on app exit");
                 let _ = child.kill();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foreign_listener_is_rejected_without_touching_it() {
+        let foreign = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = foreign.local_addr().unwrap().port();
+        assert!(require_available_port(port)
+            .unwrap_err()
+            .contains("BODHI_BACKEND_PORT"));
+        assert!(std::net::TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port)).is_ok());
+        drop(foreign);
+        assert!(require_available_port(port).is_ok());
+    }
+
+    #[test]
+    fn only_complete_owned_bound_message_establishes_readiness() {
+        let status = StartupStatus::default();
+        let mut output = Vec::new();
+        consume_output(
+            &mut output,
+            b"Starting unified server on 127.0.0.1:9562...\n",
+            9562,
+            &status,
+        );
+        consume_output(
+            &mut output,
+            b"Unified server running on http://127.0.0.1:9999\n",
+            9562,
+            &status,
+        );
+        consume_output(
+            &mut output,
+            b"Unified server running on http://127.0.0.1:95620\n",
+            9562,
+            &status,
+        );
+        assert_eq!(status.0.load(Ordering::SeqCst), 0);
+        consume_output(
+            &mut output,
+            b"INFO Unified server running on http://127.",
+            9562,
+            &status,
+        );
+        consume_output(&mut output, b"0.0.1:9562", 9562, &status);
+        assert_eq!(status.0.load(Ordering::SeqCst), 0);
+        consume_output(&mut output, b"\n", 9562, &status);
+        assert_eq!(status.0.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn termination_before_or_after_bound_signal_never_passes_health() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        for ready_first in [false, true] {
+            let status = StartupStatus::default();
+            if ready_first {
+                status.0.store(1, Ordering::SeqCst);
+            }
+            status.0.store(2, Ordering::SeqCst);
+            consume_output(
+                &mut Vec::new(),
+                b"Unified server running on http://127.0.0.1:9562\n",
+                9562,
+                &status,
+            );
+            assert!(wait_for_health(port, 1, Some(&status), None)
+                .await
+                .unwrap_err()
+                .contains("exited"));
+        }
+    }
+
+    #[tokio::test]
+    async fn unowned_http_health_is_never_probed_before_the_child_binds() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let status = StartupStatus::default();
+        assert!(wait_for_health(port, 1, Some(&status), None).await.is_err());
+        listener.set_nonblocking(true).unwrap();
+        assert_eq!(
+            listener.accept().unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
+    }
+
+    #[test]
+    fn local_logging_preserves_preferences_and_enables_the_owned_bind_signal() {
+        assert_eq!(
+            local_log_filter("warn"),
+            "warn,bamboo_server::server::entrypoints=info"
+        );
+        assert_eq!(
+            local_log_filter(""),
+            "info,bamboo_server::server::entrypoints=info"
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,9 @@
     "externalBin": [
       "binaries/bamboo"
     ],
+    "resources": {
+      "../.bodhi-frontend/": "frontend/"
+    },
     "macOS": {
       "signingIdentity": "Zenith Nova Code Signing"
     },


### PR DESCRIPTION
## Summary

Closes #62. Bounded local-build child of bigduu/Zenith#187.

- Ordinary local web/dev/preview/Tauri entrypoints now select sibling `@bigduu/lotus-next`; missing or wrong sources fail with actionable guidance, with no implicit old Lotus/package fallback.
- Build and validate the production asset graph, package identity, source revision/dirty status and deterministic content hash. Pin the receipt in the executable, bundle the verified resources, rehash them on launch, and pass the owned resolved `--static-dir` to an API-only Bamboo sidecar.
- Inject only the owned numeric backend port before frontend modules execute. Require the owned child's post-bind readiness signal plus health and exact index hash; refuse a conflicting local service without reusing or killing it. Preserve managed-child shutdown ownership.
- Replace only Tauri's generated frontend resource leaf on rebuild so removed chunks cannot remain in an overlaid bundle. Test symlink/path boundaries and JS/Rust canonical hash ordering.
- Keep explicit `LOTUS_SOURCE=package` / `@bigduu/lotus` release assembly compatible with both current Bamboo producer layouts. Document that this exception ends at #187's formal consumer cutover; no release workflow is dispatched here.

## Test Plan

- [x] `npm run test:build`: 15 passing tests, including source selection, production assets, identity changes, symlink rejection, forced API-only local assembly, and fresh/partial/ambiguous legacy producer outputs.
- [x] Migration/docs-boundary guards and `git diff --check`.
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --release --locked -- -D warnings`.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --release --locked`: 44 passing tests.
- [x] Lotus Next production verification: type/lint/architecture/build/package gates, 989 unit tests, and built-artifact E2E 22 passed / 2 explicitly skipped. Local Node is 26.5.1; this does not claim a local Node 22/24 matrix.
- [x] Actual ordinary `web:dev` and `preview` entrypoints serve Lotus Next. Actual published `@bigduu/lotus@2026.8.28` dist stages successfully; actual Bamboo main/root and dev/crate frontend producers both generate the expected compatible zip/manifest pair.
- [x] Actual `npm run tauri:build -- --bundles app` with `LOTUS_SOURCE` and package overrides unset, using explicit isolated source paths only. An intentionally stale generated chunk disappears from both rebuilt resource destinations.
- [x] Real macOS acceptance described below, with two complete launches of the final-source bundle.
- [x] Independent exact-head review: PASS at `71fc4decbe90e1b445b43a5d6db3352f51192cd9`. All 7 [Bodhi CI jobs](https://github.com/bigduu/Bodhi-AI/actions/runs/34018603633) pass: frontend, Linux/macOS/Windows backend tests, and Linux/macOS/Windows Tauri bundles.

## Desktop acceptance and exact identities

The built app used a distinct test identifier (`com.bodhi.acceptance62`), isolated data/config/workspaces, a loopback synthetic OpenAI fixture, and a sandbox denying the user's real Bamboo/Jiandu stores and all original Bodhi/Bamboo/Lotus Next source directories. The app was copied out of its source tree before launching. No installed app or real provider credentials were used.

- Bodhi source head: `71fc4decbe90e1b445b43a5d6db3352f51192cd9`.
- Lotus Next source: `d8a77943ce9ef7486d0d141ec8ad313ac74bb610`, clean; 34 files; content SHA-256 `d20ecb9efb4e5d21cb6478e0d9ace2ea0818c881811fcb0039da4a29395e7dd7`.
- Served index SHA-256, identical on both launches: `35adee0ecf4e2703494676603ba105bcb94432329835ea98a4dbdc96d73bc8af`.
- Bamboo source: `486b6c02e68fc8118b74f49d91ae9eaab5cdb8a2`; the local build forces `BAMBOO_FRONTEND_BUILD_MODE=api-only`.
- Ad-hoc-signed bundled binaries: Bodhi SHA-256 `738a3eb7eb35c4966949005b8f7feeea7e0ebab0cab87d51a0f4cd2f115e179a`; Bamboo SHA-256 `9789a62860fdbe6ca3fe9ffc7cc36a61f0fd38ae2e97102f3ae7c14d3480dbf6`. Deep/strict code-sign verification passes. This is a local acceptance bundle, not a notarized release.
- Final first launch: real WKWebView on port 19662, managed Bamboo PID 47662 with parent 47650 and `--static-dir` under the relocated app's resources. A native composer action produced `BODHI_62_ASSISTANT`; after normal Quit both owned processes disappeared and the port was released.
- Final second launch: the same index hash, restored session `ee879e3e-58b5-40b7-800e-0c4a3a4b5e2a` with 5 stored messages, both user/assistant exchanges visible, and the selected Light theme preserved. About reports `Bodhi · lotus-next`.
- Negative native launch: an independently owned fixture listener occupied port 19662. Bodhi displayed the actionable port-collision message, did not spawn/reuse a backend, and the listener survived with **zero HTTP requests**.
- Negative native launch: modifying bundled `index.html` (then ad-hoc re-signing that disposable test copy) displayed the content-hash failure and rebuild instruction, without starting Bamboo.

## Screenshots / native UI evidence

Native macOS screenshots were captured during acceptance and shown in the implementation task: (1) restored light-theme conversation with two actual assistant replies; (2) General settings with Light selected and `Bodhi · lotus-next`; (3) port-collision error; (4) damaged-resource error. No frontend visual source is changed by this PR. The exact accessibility observations and artifact/process checks above record the same acceptance state; screenshots are not a replacement for those checks.

## Scope and deferred gates

Bodhi-only: 13 core files plus two READMEs, 1,216 net lines. No Bamboo/Lotus Next production-source changes. This does **not** complete formal release-train publication/cutover, archive Lotus, certify Linux/Windows releases, or claim the broader root/child Jiandu durable-memory restart gate from #187. Existing user worktrees and unrelated WIP remain untouched.

After merge, update only Zenith's Bodhi gitlink to the true merge commit through a focused independently reviewed pointer PR.
